### PR TITLE
docs(proposal): v1.2 권한 위계 다운스트림 어댑터 reference (Issue #1 follow-up)

### DIFF
--- a/.claude/skills/humanize-korean/references/proposals/README.md
+++ b/.claude/skills/humanize-korean/references/proposals/README.md
@@ -1,0 +1,110 @@
+# Voice-Aware Adapter Reference (Issue #1 follow-up)
+
+A sanitized reference for a downstream caller wrapping `humanize-korean`
+with author-specific voice context, fully aligned with the v1.2 권한 위계
+defined in `references/ai-tell-taxonomy.md` (commit `bfcf676`, 2026-04-25).
+
+This is the adapter reference the maintainer requested in the
+[Issue #1](../../issues/1) thread. It documents how a downstream skill
+honors the v1.2 contract while still preserving authorial intent on
+long-form Korean manuscripts.
+
+## Why this exists
+
+`humanize-korean` is a strong general-purpose AI-tell remover. On a
+long-form manuscript with a strong authorial voice, several patterns
+generate **false positives** when the author's choices are intentional:
+
+| humanize-korean pattern | Authorial intent that triggers false positive |
+|---|---|
+| E-2 동일 종결어미 반복 | Single-sentence-per-thought rhythm |
+| J-3 대시 1~2회 제한 | Em-dash as a structural device |
+| C-3 반복 헤딩 제거 | Verb-form chapter headings in book mode |
+| C-4 문단 첫 문장 요약 공식 | Scene-first paragraph entries |
+| A-10 "할 수 있다" 남발 | Book-specific mandate to use 할 수 있다 |
+
+The adapter does not weaken humanize-korean. It carries the author's
+explicit voice profile through the call so intended elements are preserved
+while real AI tells are still caught.
+
+## How this adapter complies with v1.2 권한 위계
+
+| Clause | Maintainer's rule | Adapter behavior |
+|---|---|---|
+| §1 default-on | Objective taxonomy applies unless rebutted | Default run unchanged when no voice profile is passed |
+| §2 opt-in | Voice profile activates only with explicit `author-context.yaml` | No path-based or sidecar auto-load |
+| §3 allowed mechanisms | Pattern-ID on/off, threshold relaxation, Do-NOT keyword whitelist only | Schema rejects free-text fields |
+| §4 forbidden patterns | A-8, C-5, D-1..D-6 cannot be disabled | Validator rejects these in `disabled_pattern_ids`; threshold relaxation for D-1..D-6 capped at multiplier 2.0 |
+| §5 분리 검증 | naturalness-reviewer must not see voice profile | Adapter's call envelope strips voice-profile fields before invoking the reviewer layer |
+| §6 회귀 게이트 | New disable options gated on external regression cases | This PR is intentionally proposal-only; merge gated on external test cases |
+
+## Files
+
+- [`humanize-adapter-reference.md`](humanize-adapter-reference.md) —
+  adapter logic from the downstream caller's perspective, sanitized
+- [`author-context-schema.proposal.yaml`](author-context.schema.yaml) —
+  strawman schema implementing §3 allowed mechanisms (the maintainer's
+  authoritative schema, when published, takes precedence)
+- `README.md` (this file)
+
+## What was stripped
+
+The internal version of this adapter contained book-specific data (central
+metaphors, mandate phrasings, brand-asset names) and personal paths. All
+of that is replaced with `<PLACEHOLDER>` tokens. The structure — track
+classification, voice profile injection, naturalness fence, hard-block
+paths — is what the maintainer asked to see. Personal data is not part of
+this contribution.
+
+## Open questions for the maintainer
+
+1. **Pattern ID stability** — `disabled_pattern_ids` requires a stable
+   public pattern ID surface (E-1, E-2, J-3, C-3, C-4, A-10, etc.). The
+   IDs in `references/ai-tell-taxonomy.md` look stable already; should
+   they be treated as a public API and version-bumped on any rename?
+
+2. **Voice-blind reviewer enforcement** — §5 says naturalness-reviewer
+   must not receive voice profile. How is this enforced in the agent
+   topology today? The adapter assumes a separate agent invocation; if
+   the topology changes (e.g. shared context), §5 needs an architectural
+   guarantee, not just a documentation note.
+
+3. **Threshold multiplier bounds** — the strawman caps at [0.5, 2.0]. Is
+   2.0 the right ceiling, or should threshold relaxation for
+   permanent-on patterns (D-1..D-6) be capped lower (e.g. 1.5) to make
+   threshold-abuse-as-disable harder?
+
+4. **Hard-block paths** — adapter-side convention or codified into
+   humanize-korean? The adapter treats them as caller-side; the
+   maintainer might prefer a humanize-korean-side default-deny list for
+   fiction.
+
+## §6 external validation plan
+
+The adapter author's prior in-the-wild result (350+ false positives
+suppressed on a single manuscript) is **self-reported**. Merging this
+reference and any follow-up disable options into v1.2 main is gated on
+external regression cases per §6. We need 2–3 cases authored by people
+**other than this PR's author**:
+
+- [ ] Third-party AI-drafted essay (1)
+- [ ] Plain-tone report or memo (1)
+- [ ] Quote-heavy column or interview piece (1)
+
+For each case: run humanize-korean **without** the adapter, then **with**
+the adapter (using a voice profile authored for that other author), and
+compare findings. The adapter is valid only if it preserves the other
+author's voice-specific intent **and** still catches generic AI tells
+(especially A-8, C-5, D-1..D-6, which must remain default-on).
+
+We are recruiting case authors via a separate Issue thread; PR is held
+in proposal state until at least 2 external cases are evaluated.
+
+## Disclaimer
+
+This is a **proposal**, not a request to merge as-is. The maintainer's
+own authoritative `author-context.yaml` schema (planned per the v1.2
+commit message: "v1.2 후속 작업 — author-context.yaml 스키마, 에이전트
+주입 분리") supersedes this strawman. We submit this reference so the
+contract is concretely documented from a downstream caller's
+perspective and so the maintainer has a working example to react to.

--- a/.claude/skills/humanize-korean/references/proposals/author-context-schema.yaml
+++ b/.claude/skills/humanize-korean/references/proposals/author-context-schema.yaml
@@ -1,0 +1,117 @@
+# author-context.yaml — schema proposal for humanize-korean v1.2
+#
+# Strawman schema implementing the v1.2 권한 위계 (Authority Hierarchy)
+# defined in references/ai-tell-taxonomy.md (commit bfcf676, 2026-04-25).
+# Submitted as a downstream-caller's reference; the maintainer's own SSOT
+# schema takes precedence if they differ.
+#
+# Compliance with v1.2 권한 위계:
+#   §1 default-on ........... voice profile is opt-in, never auto-loaded
+#   §2 explicit yaml ........ this file is the only injection vector
+#   §3 allowed mechanisms ... pattern_id on/off, threshold relaxation,
+#                             Do-NOT 키워드 화이트리스트 (no free-text)
+#   §4 forbidden patterns ... A-8, C-5, and D-1..D-6 cannot be disabled
+#                             (D-1..D-6 may have threshold relaxation only)
+#   §5 분리 검증 ............ this file MUST NOT reach naturalness-reviewer
+#   §6 회귀 테스트 게이트 ... new fields require external regression cases
+
+schema_version: "1.0"
+
+# ---------------------------------------------------------------------------
+# author — display + voice anchors
+# ---------------------------------------------------------------------------
+author:
+  display_name: string            # used only in human-facing reports;
+                                  # NOT interpolated into model prompts
+  voice_anchors:                  # short declarative phrases (max 6).
+                                  # Advisory framing for the rewriter; cannot
+                                  # disable a pattern. Carrying intent here
+                                  # means callers don't need a genre-level
+                                  # off-switch (which v1.2 §3 forbids).
+    - string                      # e.g. "single sentence per thought"
+    - string                      # e.g. "concrete example over abstraction"
+
+# ---------------------------------------------------------------------------
+# pattern_overrides — the ONLY structured override surface (§3)
+# ---------------------------------------------------------------------------
+pattern_overrides:
+
+  # §3 allowed: pattern_id on/off
+  disabled_pattern_ids:
+    - string                      # e.g. "J-3", "E-2"
+                                  #
+                                  # Schema validator MUST reject any of:
+                                  #   - "A-8"      (이중 피동)
+                                  #   - "C-5"      (이모지 남발)
+                                  #   - "D-1".."D-6" (AI 특유 관용구)
+                                  #   - any future pattern marked
+                                  #     "permanent default-on" in v1.2+
+                                  # per v1.2 권한 위계 §4.
+
+  # §3 allowed: threshold relaxation
+  threshold_relaxations:
+    - pattern_id: string          # e.g. "J-3"
+      multiplier: number          # range [0.5, 2.0]; out-of-range rejected.
+                                  #
+                                  # D-1..D-6 ARE allowed here (single-use
+                                  # leniency per §4 final clause), but
+                                  # multiplier is hard-capped at 2.0 to
+                                  # prevent effective disable via threshold.
+
+  # §3 allowed: Do-NOT 키워드 화이트리스트
+  do_not_keywords:                # exact phrases the rewriter must not edit.
+                                  # This is humanize-korean's standard Do-NOT
+                                  # mechanism extended with author-specific
+                                  # protected phrases.
+    - phrase: string              # exact string match
+      kind: enum                  # one of:
+                                  #   metaphor          — protected imagery
+                                  #   signature_phrase  — author's recurring
+                                  #                       first-person line
+                                  #   structural_block  — section/chapter
+                                  #                       structural marker
+                                  #   citation          — fixed quote that
+                                  #                       must not be edited
+
+# ---------------------------------------------------------------------------
+# hard_blocks — paths where the upstream caller (adapter) refuses to invoke
+# humanize-korean at all. NOT enforced by humanize-korean itself; this is a
+# convention for adapters and orchestrators.
+# ---------------------------------------------------------------------------
+hard_blocks:
+  paths:                          # globs. Caller rejects before invoking.
+    - string                      # e.g. "**/fiction/**"
+    - string                      # e.g. "**/legal-filings/**"
+    - string                      # e.g. "**/received-from-others/**"
+
+# ---------------------------------------------------------------------------
+# reviewer_contract — invariant the loader MUST honor (§5)
+# ---------------------------------------------------------------------------
+reviewer_contract:
+  naturalness_reviewer_voice_blind: true
+                                  # Schema validator rejects this file if
+                                  # set to false. The naturalness-reviewer
+                                  # agent must NOT receive this file's
+                                  # contents per v1.2 권한 위계 §5.
+
+# ---------------------------------------------------------------------------
+# Implementer notes
+# ---------------------------------------------------------------------------
+# 1. All string fields are interpolated into model prompts verbatim. Treat
+#    this file as untrusted input. The schema validator must reject any
+#    field containing characters that could escape prompt context (triple
+#    backticks, role-prefix tokens like "system:" / "assistant:", etc.).
+#    Maintain a denylist; do not rely on regex-only sanitization.
+#
+# 2. Validation runs BEFORE prompt construction. A malformed file aborts the
+#    run; it does NOT silently fall back to humanize-korean default. Silent
+#    degradation hides production bugs.
+#
+# 3. Telemetry: the loader should record which pattern_ids were disabled,
+#    which thresholds were relaxed, and which keywords triggered Do-NOT
+#    suppression — per call. This is what makes the §6 regression gate
+#    measurable.
+#
+# 4. The maintainer's authoritative schema (planned per the v1.2 commit
+#    message: "v1.2 후속 작업(author-context.yaml 스키마, 에이전트 주입 분리)")
+#    takes precedence over this strawman.

--- a/.claude/skills/humanize-korean/references/proposals/voice-aware-adapter.md
+++ b/.claude/skills/humanize-korean/references/proposals/voice-aware-adapter.md
@@ -1,0 +1,196 @@
+# Voice-Aware Adapter — Downstream Caller Reference (sanitized)
+
+A reference implementation for **downstream callers** that wrap
+`humanize-korean` with author-specific voice context, fully aligned with the
+v1.2 권한 위계 (Authority Hierarchy) defined in
+`references/ai-tell-taxonomy.md` (commit `bfcf676`, 2026-04-25).
+
+> This is the reference the maintainer requested in Issue #1 thread. It is
+> **not** a proposal to replace humanize-korean's built-in mechanisms; it is
+> the contract a wrapping skill (in our case, a writing-style skill) needs
+> to honor when invoking humanize-korean on long-form, author-voiced
+> manuscripts.
+
+## What this adapter is for
+
+`humanize-korean` is a strong general-purpose AI-tell remover. Run it raw on
+a long-form manuscript with a strong authorial voice and it flags
+**intended** style elements as AI tells:
+
+- Repeated `~다.` endings (chosen as a "single sentence one thought" rhythm)
+  → flagged as **E-2** (동일 종결어미 반복)
+- Em-dashes used as a structural rhythm device
+  → flagged as **J-3** (대시 1~2회 제한)
+- Single-sentence paragraphs as deliberate beats
+  → potentially conflated with **C-4** (문단 첫 문장 요약 공식)
+
+The adapter sits **in front of** humanize-korean and injects an explicit
+voice profile so these intended elements survive the pass, while real AI
+tells (번역투, hype 어휘, 영구 default-on patterns) still get caught.
+
+## v1.2 권한 위계 compliance map
+
+The adapter is bound by every clause of §1–§6:
+
+| Clause | Adapter behavior |
+|---|---|
+| §1 객관 분류 우선 | Default humanize-korean run is unchanged. Adapter only takes effect when a valid `author-context.yaml` is explicitly passed. |
+| §2 opt-in 주입 | No path-based or sidecar auto-discovery. The adapter requires an explicit `author_context` argument; absence = no injection. |
+| §3 허용 메커니즘 | Adapter passes only three things: `disabled_pattern_ids`, `threshold_relaxations`, `do_not_keywords`. No free-text mandates. |
+| §4 무력화 불가 | Adapter's schema validator rejects any `disabled_pattern_ids` containing **A-8, C-5, D-1..D-6**. Threshold relaxation for D-1..D-6 is allowed but capped (multiplier ≤ 2.0). |
+| §5 분리 검증 | Adapter never passes voice-profile fields into the `naturalness-reviewer` invocation. This is enforced by the call envelope, not by convention. |
+| §6 회귀 게이트 | Adapter changes are gated on external regression cases (see this PR's discussion thread). |
+
+## Call-time inputs
+
+```text
+input_path:        path to the manuscript
+author_context:    explicit path to author-context.yaml (required for any
+                   voice-aware behavior; absence falls through to default
+                   humanize-korean run)
+genre:             one of humanize-korean's published genres
+output_workspace:  scratch directory outside any indexed vault
+```
+
+The adapter never discovers context implicitly. There is no path-based
+auto-load.
+
+## Pipeline
+
+```
+input → [adapter pre-pass] → humanize-korean → [adapter post-pass] → report
+            │                                       │
+            │                                       └── filters findings
+            │                                           against voice profile
+            │                                           and do_not_keywords;
+            │                                           NEVER adds findings.
+            │
+            └── pre-pass:
+                  1. Hard-block check (reject and explain)
+                  2. Track classification (column / report / blog / book / etc.)
+                  3. Schema-validate author-context.yaml
+                  4. Build the humanize-korean call envelope:
+                       - genre
+                       - disabled_pattern_ids       (validated, §4 enforced)
+                       - threshold_relaxations      (validated, capped)
+                       - do_not_keywords            (added to standard Do-NOT)
+                  5. Invoke humanize-korean
+```
+
+The `naturalness-reviewer` layer inside humanize-korean **must remain
+voice-blind** per §5 — the adapter does not pass `author_context` into that
+layer. This is a contract, not a convenience: it preserves an independent
+check on whether the final text reads as natural Korean prose, regardless
+of what the voice profile claims.
+
+## Track classification
+
+Track is determined from content + invocation context, not from file path
+alone. Path patterns are advisory.
+
+| Track | Characteristics | Genre passed |
+|---|---|---|
+| Long-form non-fiction | Chapter headings, narrative beats, central metaphor | `book_essay` (proposed new genre — separate discussion) |
+| Report / proposal | Structured sections, citations, executive summary | `report` |
+| Blog / SNS / short-form | Conversational, single topic | `blog` |
+| Research / data analysis | Source verification is the point | (skip — humanize-korean inappropriate) |
+| Email / memo | Short, transactional | (skip — overkill) |
+| Fiction | Dialog, scene structure, deliberate voice | **HARD BLOCK** |
+
+## Hard blocks (caller-side convention)
+
+The adapter rejects calls outright for caller-defined sensitive paths:
+
+- Fiction manuscripts (any path matching the configured fiction glob)
+- Legal-process documents (court filings, retrial materials, etc.)
+- Third-party manuscripts (`received-from-others` glob)
+
+Hard-block paths are configured per-installation in `author-context.yaml`,
+not hard-coded. This is a caller convention, not a humanize-korean
+requirement.
+
+When a hard block fires, the adapter returns:
+
+```text
+This file matches a hard-block rule (<reason>). humanize-korean will not run.
+Suggested alternatives: direct manual revision, or voice-style skill alone.
+```
+
+## Author voice profile injection
+
+See `author-context-schema.proposal.yaml` for the full schema. The adapter
+passes exactly four fields into the humanize-korean call:
+
+1. `voice_anchors` — short declarative phrases describing intentional traits
+   (advisory only; cannot disable a pattern, per §3 free-text prohibition
+   reading)
+2. `disabled_pattern_ids` — pattern IDs the author has explicitly opted out
+   of (validator enforces §4 forbidden list)
+3. `threshold_relaxations` — numeric multipliers on specific pattern
+   thresholds (capped at 2.0)
+4. `do_not_keywords` — exact phrases extending humanize-korean's standard
+   Do-NOT list
+
+**No free-text mandate field is passed through.** This is the maintainer's
+constraint and the adapter enforces it: the schema rejects any string field
+that isn't part of the structured fields above.
+
+## Post-pass filtering
+
+After humanize-korean returns findings, the adapter filters against the
+voice profile:
+
+- Findings whose pattern ID is in `disabled_pattern_ids` → suppressed,
+  reported as "preserved by voice profile (`<pattern_id>`, N occurrences)"
+- Findings whose threshold was relaxed and now sits below the relaxed
+  threshold → suppressed, reported as "below relaxed threshold"
+- Findings that touch a phrase in `do_not_keywords` → suppressed, reported
+  as "preserved by Do-NOT keyword"
+- All other findings → passed through unchanged
+
+The post-pass **never adds** findings. It only suppresses, and it reports
+every suppression so the user can audit what was protected. Suppressions
+are also written to a structured telemetry log to support the §6 regression
+gate.
+
+## Result format
+
+```text
+1. Quality grade and severity-weighted score (from humanize-korean)
+2. Real recommendations (post-pass survivors only)
+3. Before → after pairs (one per surviving finding)
+4. Preserved-by-voice-profile section
+   - "<pattern_id>: N occurrences preserved (reason: <voice_anchor>)"
+5. Author decisions (accept / reject)
+```
+
+## Failure modes (regression checklist)
+
+- Adapter ran on a hard-blocked path → fix: tighten glob
+- Author's central metaphor got rewritten → fix: ensure exact phrase in
+  `do_not_keywords` with `kind: metaphor`
+- Change rate exceeded 30% on a long manuscript → fix: voice profile likely
+  not loaded; verify `author_context` was passed
+- Author's first-person signature was flattened → fix: add to
+  `do_not_keywords` with `kind: signature_phrase`
+- Naturalness reviewer's verdict aligns suspiciously with voice anchors →
+  contract violation: voice profile leaked into reviewer layer (§5)
+- D-1..D-6 was disabled in `disabled_pattern_ids` → schema validator should
+  have rejected. Bug in validator. Patch the validator before any further
+  runs.
+
+## What this adapter does NOT do
+
+- Disable patterns at the genre level (v1.2 §3 forbids; per-author opt-in
+  via `disabled_pattern_ids` is the only supported mechanism)
+- Accept free-text mandates ("treat `~할 것이다` as forbidden") — only
+  pattern IDs and numeric thresholds are accepted
+- Auto-discover sidecar config files near the manuscript (v1.2 §2)
+- Pass voice profile into the naturalness-reviewer layer (v1.2 §5)
+- Override A-8, C-5, or D-1..D-6 disable (v1.2 §4)
+
+## Version
+
+- Reference v0.1 (sanitized): 2026-04-25
+- Aligned with: `references/ai-tell-taxonomy.md` v1.1 + 권한 위계 절
+  (commit `bfcf676`)

--- a/.claude/skills/humanize-korean/references/proposals/voice-aware-adapter.md
+++ b/.claude/skills/humanize-korean/references/proposals/voice-aware-adapter.md
@@ -90,12 +90,14 @@ alone. Path patterns are advisory.
 
 | Track | Characteristics | Genre passed |
 |---|---|---|
-| Long-form non-fiction | Chapter headings, narrative beats, central metaphor | `book_essay` (proposed new genre — separate discussion) |
+| Long-form non-fiction | Chapter headings, narrative beats, central metaphor | existing genre (`column` / `report`) + voice profile |
 | Report / proposal | Structured sections, citations, executive summary | `report` |
 | Blog / SNS / short-form | Conversational, single topic | `blog` |
 | Research / data analysis | Source verification is the point | (skip — humanize-korean inappropriate) |
 | Email / memo | Short, transactional | (skip — overkill) |
 | Fiction | Dialog, scene structure, deliberate voice | **HARD BLOCK** |
+
+> Long-form non-fiction은 별도 장르를 신설하지 않는다. 메인테이너 결정(Issue #1, v1.2 schema)에 따라 기존 장르 + voice profile로 처리한다. 장르 단위로 패턴을 끄면 작가 voice 백도어가 생기므로, 패턴 opt-out은 author profile의 `disabled_pattern_ids`로만 한다.
 
 ## Hard blocks (caller-side convention)
 


### PR DESCRIPTION
v1.2 권한 위계 commit `bfcf676` follow-up입니다. Issue #1에서 어댑터 reference를 PR로 부탁하신 것에 대한 응답입니다.

## 추가 위치

`.claude/skills/humanize-korean/references/proposals/` 하위에 3개 파일을 추가합니다.

- `proposals/README.md` — Issue #1 follow-up 컨텍스트와 §1-§6 매핑표
- `proposals/voice-aware-adapter.md` — 다운스트림 caller가 humanize-korean을 wrap할 때의 어댑터 로직
- `proposals/author-context-schema.yaml` — §3 허용 메커니즘만 노출하는 strawman 스키마

본체 `.claude/skills/humanize-korean/SKILL.md` 또는 `references/ai-tell-taxonomy.md`는 건드리지 않습니다. SSOT는 메인테이너 영역으로 남겨둡니다.

## v1.2 권한 위계 정합성

| 절 | 메인테이너 규칙 | 어댑터 거동 |
|---|---|---|
| §1 default-on | 객관 분류 우선 | voice profile 미주입 시 humanize-korean default 그대로 |
| §2 opt-in | 명시 yaml만 | 경로 기반·sidecar 자동 로드 없음 |
| §3 허용 메커니즘 | pattern_id on/off, 임계 완화, Do-NOT 키워드 화이트리스트 | 자유 텍스트 필드 schema에서 거부 |
| §4 무력화 불가 | A-8, C-5, D-1..D-6 | `disabled_pattern_ids`에서 schema validator가 거부; D-1..D-6 임계 완화는 multiplier ≤ 2.0 캡 |
| §5 분리 검증 | naturalness-reviewer는 voice profile 미주입 | 호출 envelope 단계에서 voice profile 필드 strip |
| §6 회귀 게이트 | 외부 케이스 2~3건 통과 후 추가 | 본 PR은 proposal 상태로 대기, 외부 검증 케이스 모집 Issue 별도 개설 예정 |

## 머지 보류 요청

본 PR은 **proposal**로 제출하며, §6 외부 회귀 케이스 2~3건이 통과되기 전에는 머지하지 않으셔도 됩니다. 외부 케이스 결과에 따라 schema·어댑터 본문이 바뀔 수 있고, 메인테이너 본인이 만드실 권위 `author-context.yaml` 스키마와 충돌하면 그쪽이 우선되도록 README에 명시했습니다.

## 메인테이너에게 드리는 4가지 질문

본 PR README에 정리되어 있지만 요약합니다.

1. **패턴 ID 안정성** — `disabled_pattern_ids`가 API로 성립하려면 분류 체계의 ID(E-2, J-3 등)가 안정 surface여야 합니다. 현재 `ai-tell-taxonomy.md` 그대로 public API로 보아도 될까요?
2. **voice-blind reviewer 강제 방식** — §5는 어떤 아키텍처로 강제되고 있나요? (별도 에이전트 호출 / context redaction / 그 외)
3. **임계 multiplier 상한** — strawman은 2.0 캡인데, D-1..D-6에 대해서는 더 낮춰야 (예: 1.5) 임계 우회를 통한 사실상 무력화를 막을 수 있을지 의견 부탁드립니다.
4. **hard-block 위치** — 어댑터 측 컨벤션으로 두는 게 맞을지, 본체 default-deny가 나은지.

## 다음 단계

§6 외부 회귀 케이스 모집은 본 레포에 별도 Issue로 열겠습니다. PR과 분리해서 진행하면 PR 본체 리뷰 사이클이 외부 케이스 수집과 독립적으로 굴러갈 수 있습니다.

거듭, 너무 좋은 v1.2 권한 위계 SSOT 감사드립니다.