### PR TITLE
[codex] Add VSCode Codex task launcher

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,48 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "Codex: open CLI",
+      "type": "process",
+      "command": "powershell.exe",
+      "args": [
+        "-NoProfile",
+        "-ExecutionPolicy",
+        "Bypass",
+        "-File",
+        "${workspaceFolder}\\scripts\\vscode-codex.ps1"
+      ],
+      "options": {
+        "cwd": "${workspaceFolder}"
+      },
+      "problemMatcher": [],
+      "presentation": {
+        "reveal": "always",
+        "focus": true,
+        "panel": "new"
+      }
+    },
+    {
+      "label": "Codex: humanize-korean",
+      "type": "process",
+      "command": "powershell.exe",
+      "args": [
+        "-NoProfile",
+        "-ExecutionPolicy",
+        "Bypass",
+        "-File",
+        "${workspaceFolder}\\scripts\\vscode-codex.ps1",
+        "$humanize-korean"
+      ],
+      "options": {
+        "cwd": "${workspaceFolder}"
+      },
+      "problemMatcher": [],
+      "presentation": {
+        "reveal": "always",
+        "focus": true,
+        "panel": "new"
+      }
+    }
+  ]
+}

--- a/scripts/vscode-codex.ps1
+++ b/scripts/vscode-codex.ps1
@@ -1,0 +1,25 @@
+param(
+  [Parameter(ValueFromRemainingArguments = $true)]
+  [string[]] $CodexArgs
+)
+
+$ErrorActionPreference = "Stop"
+
+$command = Get-Command codex.exe -ErrorAction SilentlyContinue
+if ($command) {
+  $codex = $command.Source
+} else {
+  $extensionRoot = Join-Path $env:USERPROFILE ".vscode\extensions"
+  $codex = Get-ChildItem -Path $extensionRoot -Recurse -Filter codex.exe -ErrorAction SilentlyContinue |
+    Where-Object { $_.FullName -like "*\openai.chatgpt-*\bin\windows-x86_64\codex.exe" } |
+    Sort-Object LastWriteTime -Descending |
+    Select-Object -First 1 -ExpandProperty FullName
+}
+
+if (-not $codex) {
+  Write-Error "Could not find codex.exe. Please check that the VSCode OpenAI/Codex extension is installed."
+  exit 1
+}
+
+& $codex @CodexArgs
+exit $LASTEXITCODE


### PR DESCRIPTION
﻿## What changed

- Added a VSCode task file that can launch Codex from the workspace.
- Added a PowerShell helper that locates `codex.exe` either from PATH or from the VSCode OpenAI/Codex extension directory.
- Added a direct task for starting Codex with the `$humanize-korean` skill.

## Why

VSCode tasks were previously resolving the repository's `codex` folder instead of the Codex CLI executable, and some task shells did not have `codex.exe` on PATH. The helper makes the launcher work reliably in VSCode on Windows.

## Validation

- Verified task JSON parses successfully.
- Verified the helper can run `codex --version` locally and reports `codex-cli 0.140.0-alpha.2`.

## Notes

The local `codex/skills/humanize-korean/references` junction change is a Windows-only local checkout artifact and is intentionally excluded from this PR.
