### PR TITLE
[codex] installer의 only 옵션과 홈 디렉터리 감지 보강

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,6 +1,6 @@
 # 설치 가이드 (Install)
 
-Humanize KR은 **Claude Code**와 **OpenAI Codex**, **Gemini CLI(Antigravity)** 에서 전역으로 쓸 수 있습니다.
+Humanize KR은 **Claude Code**와 **OpenAI Codex**, **Gemini CLI(Antigravity)** 에서 전역으로 사용할 수 있습니다.
 
 | 도구 | 모드 | 설치 방법 |
 |---|---|---|
@@ -8,7 +8,7 @@ Humanize KR은 **Claude Code**와 **OpenAI Codex**, **Gemini CLI(Antigravity)** 
 | Codex | Fast(단일 호출)만 | 클론 + `install.sh` |
 | Gemini CLI | Fast(단일 호출)만 | ① `gemini extensions install`(권장) / ② 클론 + `install.sh` |
 
-> Codex와 Gemini는 Claude식 다중 서브에이전트 파이프라인을 결정적으로 실행하지 못해, 단일 호출 Fast Path만 제공합니다. 정밀 검증이 필요하면 Claude Code의 `--strict`를 사용하세요.
+> Codex와 Gemini는 Claude식 다중 서브에이전트 파이프라인을 안정적으로 실행하기 어려워, 단일 호출 Fast Path만 제공합니다. 정밀 검증이 필요하면 Claude Code의 `--strict`를 사용하세요.
 
 ---
 
@@ -23,7 +23,7 @@ Claude Code 세션에서:
 /plugin install humanize-korean@im-not-ai
 ```
 
-- 설치 후 새 세션에서 `/humanize-korean`(또는 `/humanize`, `/humanize-redo`), 혹은 자연어 트리거("이 글 AI 티 없애줘")로 발동.
+- 설치 후 새 세션에서 `/humanize-korean`(또는 `/humanize`, `/humanize-redo`)이나 자연어 트리거("이 글 AI 티 없애줘")로 실행.
 - 업데이트: `/plugin marketplace update im-not-ai` 후 `/plugin update humanize-korean`.
 - 제거: `/plugin uninstall humanize-korean`.
 - 구성요소: 스킬 3개(humanize-korean·humanize·humanize-redo) + 서브에이전트 12개가 함께 설치됩니다.
@@ -36,7 +36,7 @@ cd im-not-ai
 ./install.sh --claude-only
 ```
 
-`~/.claude/skills/`에 스킬 3개, `~/.claude/agents/`에 에이전트 12개를 **심링크**합니다(저장소를 수정하면 즉시 반영). 새 세션에서 `/humanize-korean`.
+`~/.claude/skills/`에 스킬 3개, `~/.claude/agents/`에 에이전트 12개를 **심링크**로 연결합니다(저장소를 수정하면 즉시 반영). 새 세션에서 `/humanize-korean`.
 
 ---
 
@@ -50,7 +50,7 @@ cd im-not-ai
 ./install.sh --codex-only
 ```
 
-`~/.codex/skills/humanize-korean`에 Fast Path 스킬을 심링크합니다. Codex에서 `$humanize-korean`으로 발동하거나, `/skills` 메뉴에서 선택하세요. `codex` 명령이 PATH에 없어도 `~/.codex`가 있으면 설치할 수 있습니다. `--codex-only`는 설치 대상을 Codex로만 제한합니다.
+`~/.codex/skills/humanize-korean`에 Fast Path 스킬을 심링크로 연결합니다. Codex에서는 `$humanize-korean`으로 실행하거나 `/skills` 메뉴에서 선택하세요. `codex` 명령이 PATH에 없어도 `~/.codex`가 있으면 설치할 수 있습니다. `--codex-only`는 설치 대상을 Codex로만 제한합니다.
 
 ---
 
@@ -68,11 +68,11 @@ cd im-not-ai
 |---|---|
 | (없음) | `claude`·`codex`·`gemini` 명령을 자동 감지합니다. Claude/Codex는 `~/.claude`·`~/.codex` 디렉터리도 감지합니다. |
 | `--copy` | 심링크 대신 복사. 저장소를 지워도 유지(references 심링크는 실체화). ⚠ 복사본은 `uninstall.sh`가 자동 삭제하지 않음 |
-| `--claude-only` / `--codex-only` | 해당 대상만 설치 시도. 설치 가능 여부는 `claude`/`codex` 명령 또는 `~/.claude`/`~/.codex` 감지로 판단 |
+| `--claude-only` / `--codex-only` | 선택한 대상만 설치를 시도합니다. 설치 가능 여부는 `claude`/`codex` 명령 또는 `~/.claude`/`~/.codex` 감지 결과로 판단합니다. |
 | `--gemini-only` | Gemini만 설치(`gemini extensions link` 실행) |
 | `--no-gemini` | Gemini 건너뜀 (Claude/Codex만) |
 | `--force` | 대상에 일반 파일/디렉토리가 있어도 `.bak.<ts>`로 백업 후 덮어씀 |
-| `--dry-run` | 실제 변경 없이 수행할 작업만 출력 |
+| `--dry-run` | 실제 변경 없이 할 작업만 출력 |
 | `-h`, `--help` | 도움말 |
 
 환경변수 `CLAUDE_HOME`(기본 `~/.claude`), `CODEX_HOME`(기본 `~/.codex`)로 설치 위치를 바꿀 수 있습니다.
@@ -82,16 +82,16 @@ cd im-not-ai
 ## 업데이트
 
 - **자동 감지 + 적용 (스크립트 설치, 권장)** — `./update.sh`
-  - upstream(git)에 새 버전이 있으면 자동으로 `git pull` + `install.sh` 재적용(신규 스킬/에이전트/구조 변경까지 연결).
+  - upstream(git)에 새 버전이 있으면 `git pull` 후 `install.sh`를 다시 실행합니다(신규 스킬/에이전트/구조 변경까지 연결).
   - `./update.sh --check` — 감지만(적용 안 함). 최신이면 종료코드 `0`, 업데이트 있으면 `10`.
   - `--copy`로 설치했다면 `./update.sh --copy --force`.
-- **수동** — `git pull`만 해도 심링크라 내용은 반영됩니다(신규 파일 연결은 `./install.sh` 한 번 더).
+- **수동** — 심링크 설치라 `git pull`만으로도 내용은 반영됩니다(신규 파일 연결은 `./install.sh` 한 번 더).
 - **마켓플레이스 설치** — Claude Code가 갱신을 관리합니다: `/plugin marketplace update im-not-ai` → `/plugin update humanize-korean`.
-- **주기적 무인 업데이트 (opt-in)** — 완전 자동 갱신을 원하면 cron/launchd로 `update.sh`를 거세요. 예(매주 월 09:00, 감지 시 적용):
+- **주기적 무인 업데이트 (opt-in)** — 자동 갱신을 원하면 cron/launchd로 `update.sh`를 걸어두세요. 예(매주 월 09:00, 감지 시 적용):
   ```cron
   0 9 * * 1  cd /path/to/im-not-ai && ./update.sh >> ~/.humanize-update.log 2>&1
   ```
-  알림만 원하면 `./update.sh --check`를 사용하세요. ⚠️ 자동 적용은 upstream 코드를 자동으로 받아 연결하므로 **신뢰하는 저장소에만** 거세요.
+  알림만 원하면 `./update.sh --check`를 사용하세요. ⚠️ 자동 적용은 upstream 코드를 받아 연결하므로 **신뢰하는 저장소에만** 사용하세요.
 
 ## 제거
 
@@ -102,15 +102,15 @@ cd im-not-ai
 
 ## 트러블슈팅
 
-- **"refuse: … 가 이미 있음"** — 해당 경로에 이미 다른 파일/링크가 있습니다. `--force`(백업 후 덮어쓰기) 또는 직접 정리 후 재실행하세요.
+- **"refuse: … 가 이미 있음"** — 해당 경로에 이미 다른 파일/링크가 있습니다. `--force`(백업 후 덮어쓰기)를 쓰거나 직접 정리한 뒤 재실행하세요.
 - **스킬이 안 보임** — Claude는 **새 세션**에서 로드됩니다. `claude plugin list`(마켓플레이스 설치) 또는 `ls -l ~/.claude/skills`(스크립트 설치)로 확인하세요. Codex는 `/skills` 메뉴 또는 `ls -l ~/.codex/skills`로 확인하세요.
-- **저장소 위치 이동/삭제** — 심링크 설치는 클론한 저장소 경로에 의존합니다. 저장소를 옮기면 `./uninstall.sh`(옛 경로) 후 새 경로에서 `./install.sh`를 다시 실행하거나, 위치 비의존이 필요하면 `--copy`로 설치하세요.
-- **레포 기여 개발** — 이 저장소는 에이전트를 플러그인 컨벤션(`agents/`)에, 스킬을 `.claude/skills/`에 둡니다. 저장소 안에서 직접 테스트하려면 `./install.sh`로 한 번 전역 연결한 뒤(에이전트가 `~/.claude/agents`에서 탐색됨) 사용하세요.
+- **저장소 위치 이동/삭제** — 심링크 설치는 클론한 저장소 경로에 의존합니다. 저장소를 옮겼다면 `./uninstall.sh`(옛 경로)를 실행한 뒤 새 경로에서 `./install.sh`를 다시 실행하세요. 위치에 묶이지 않는 설치가 필요하면 `--copy`를 사용하세요.
+- **레포 기여 개발** — 이 저장소는 에이전트를 플러그인 컨벤션(`agents/`)에, 스킬을 `.claude/skills/`에 둡니다. 저장소 안에서 직접 테스트하려면 `./install.sh`로 한 번 전역 연결한 뒤 사용하세요. 에이전트는 `~/.claude/agents`에서 탐색됩니다.
 
 ## 요구 사항
 
-- Claude Code: 마켓플레이스/플러그인 지원 버전. 스크립트 설치는 `claude` 명령 또는 `~/.claude`가 감지될 때 진행됩니다. `--claude-only`는 설치 대상을 Claude로만 제한합니다.
-- Codex: `~/.codex/skills` Skills를 지원하는 버전. CLI 사용자는 0.121.0 이상을 권장합니다. 스크립트 설치는 `codex` 명령 또는 `~/.codex`가 감지될 때 진행됩니다. `--codex-only`는 설치 대상을 Codex로만 제한합니다.
+- Claude Code: 마켓플레이스/플러그인 지원 버전. 스크립트는 `claude` 명령 또는 `~/.claude`를 감지하면 설치를 진행합니다. `--claude-only`는 설치 대상을 Claude로만 제한합니다.
+- Codex: `~/.codex/skills` Skills를 지원하는 버전. CLI 사용자는 0.121.0 이상을 권장합니다. 스크립트는 `codex` 명령 또는 `~/.codex`를 감지하면 설치를 진행합니다. `--codex-only`는 설치 대상을 Codex로만 제한합니다.
 - Gemini CLI: 0.14.0 이상(`gemini extensions` 명령 사용 가능).
 - macOS·Linux의 `bash`. (Windows는 WSL 권장 — 심링크 때문에.)
 
@@ -126,7 +126,7 @@ Gemini CLI 0.14.0 이상이 필요합니다.
 gemini extensions install https://github.com/epoko77-ai/im-not-ai.git
 ```
 
-- 설치 후 새 세션에서 `/humanize-korean`(또는 `/humanize`), 혹은 자연어 트리거("이 글 AI 티 없애줘")로 발동.
+- 설치 후 새 세션에서 `/humanize-korean`(또는 `/humanize`)이나 자연어 트리거("이 글 AI 티 없애줘")로 실행.
 - 업데이트: `gemini extensions update im-not-ai`.
 - 제거: `gemini extensions uninstall im-not-ai`.
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,11 +1,11 @@
 # 설치 가이드 (Install)
 
-Humanize KR은 **Claude Code**와 **OpenAI Codex CLI**, **Gemini CLI(Antigravity)** 에서 전역으로 쓸 수 있습니다.
+Humanize KR은 **Claude Code**와 **OpenAI Codex(CLI/Desktop)**, **Gemini CLI(Antigravity)** 에서 전역으로 쓸 수 있습니다.
 
 | 도구 | 모드 | 설치 방법 |
 |---|---|---|
 | Claude Code | Fast + strict(5인 파이프라인) | ① 플러그인 마켓플레이스(권장) / ② 클론 + `install.sh` |
-| Codex CLI | Fast(단일 호출)만 | 클론 + `install.sh` |
+| Codex(CLI/Desktop) | Fast(단일 호출)만 | 클론 + `install.sh` |
 | Gemini CLI | Fast(단일 호출)만 | ① `gemini extensions install`(권장) / ② 클론 + `install.sh` |
 
 > Codex와 Gemini는 Claude식 다중 서브에이전트 파이프라인을 결정적으로 실행하지 못해, 단일 호출 Fast Path만 제공합니다. 정밀 검증이 필요하면 Claude Code의 `--strict`를 사용하세요.
@@ -40,9 +40,9 @@ cd im-not-ai
 
 ---
 
-## Codex CLI
+## Codex(CLI/Desktop)
 
-Codex 0.121.0 이상(1급 Skills 지원)이 필요합니다.
+Codex CLI 0.121.0 이상 또는 `~/.codex/skills`를 읽는 Desktop 버전이 필요합니다.
 
 ```bash
 git clone https://github.com/epoko77-ai/im-not-ai.git
@@ -50,7 +50,7 @@ cd im-not-ai
 ./install.sh --codex-only
 ```
 
-`~/.codex/skills/humanize-korean`에 Fast Path 스킬을 심링크합니다. Codex에서 `$humanize-korean`으로 발동하거나, `/skills` 메뉴에서 선택하세요.
+`~/.codex/skills/humanize-korean`에 Fast Path 스킬을 심링크합니다. Codex에서 `$humanize-korean`으로 발동하거나, `/skills` 메뉴에서 선택하세요. `codex` 명령이 PATH에 없어도 `~/.codex`가 있거나 `--codex-only`를 쓰면 설치할 수 있습니다.
 
 ---
 
@@ -59,16 +59,17 @@ cd im-not-ai
 ```bash
 git clone https://github.com/epoko77-ai/im-not-ai.git
 cd im-not-ai
-./install.sh            # 설치된 claude/codex/gemini를 자동 감지해 각각 연결
+./install.sh            # claude/codex/gemini 명령 또는 ~/.claude·~/.codex를 감지해 각각 연결
 ```
 
 ### `install.sh` 옵션
 
 | 옵션 | 설명 |
 |---|---|
-| (없음) | `claude`·`codex`·`gemini` 자동 감지 후 각각 설치 (심링크) |
+| (없음) | `claude`·`codex`·`gemini` 명령을 자동 감지합니다. Claude/Codex는 `~/.claude`·`~/.codex` 디렉터리도 감지합니다. |
 | `--copy` | 심링크 대신 복사. 저장소를 지워도 유지(references 심링크는 실체화). ⚠ 복사본은 `uninstall.sh`가 자동 삭제하지 않음 |
-| `--claude-only` / `--codex-only` / `--gemini-only` | 한쪽만 |
+| `--claude-only` / `--codex-only` | CLI/홈 디렉터리 감지 없이 해당 스킬만 설치 |
+| `--gemini-only` | Gemini만 설치(`gemini extensions link` 실행) |
 | `--no-gemini` | Gemini 건너뜀 (Claude/Codex만) |
 | `--force` | 대상에 일반 파일/디렉토리가 있어도 `.bak.<ts>`로 백업 후 덮어씀 |
 | `--dry-run` | 실제 변경 없이 수행할 작업만 출력 |
@@ -102,14 +103,14 @@ cd im-not-ai
 ## 트러블슈팅
 
 - **"refuse: … 가 이미 있음"** — 해당 경로에 이미 다른 파일/링크가 있습니다. `--force`(백업 후 덮어쓰기) 또는 직접 정리 후 재실행하세요.
-- **스킬이 안 보임** — Claude는 **새 세션**에서 로드됩니다. `claude plugin list`(마켓플레이스 설치) 또는 `ls -l ~/.claude/skills`(스크립트 설치)로 확인하세요. Codex는 `/skills` 메뉴로 확인.
+- **스킬이 안 보임** — Claude는 **새 세션**에서 로드됩니다. `claude plugin list`(마켓플레이스 설치) 또는 `ls -l ~/.claude/skills`(스크립트 설치)로 확인하세요. Codex는 `/skills` 메뉴 또는 `ls -l ~/.codex/skills`로 확인하세요.
 - **저장소 위치 이동/삭제** — 심링크 설치는 클론한 저장소 경로에 의존합니다. 저장소를 옮기면 `./uninstall.sh`(옛 경로) 후 새 경로에서 `./install.sh`를 다시 실행하거나, 위치 비의존이 필요하면 `--copy`로 설치하세요.
 - **레포 기여 개발** — 이 저장소는 에이전트를 플러그인 컨벤션(`agents/`)에, 스킬을 `.claude/skills/`에 둡니다. 저장소 안에서 직접 테스트하려면 `./install.sh`로 한 번 전역 연결한 뒤(에이전트가 `~/.claude/agents`에서 탐색됨) 사용하세요.
 
 ## 요구 사항
 
-- Claude Code: 마켓플레이스/플러그인 지원 버전(`claude plugin` 명령 사용 가능).
-- Codex CLI: 0.121.0 이상(`~/.codex/skills` Skills 지원).
+- Claude Code: 마켓플레이스/플러그인 지원 버전. 스크립트 설치만 할 때는 `claude` 명령이 없어도 `~/.claude`가 있거나 `--claude-only`를 쓰면 됩니다.
+- Codex: CLI 0.121.0 이상 또는 `~/.codex/skills` Skills를 지원하는 Desktop 버전. 스크립트 설치만 할 때는 `codex` 명령이 없어도 `~/.codex`가 있거나 `--codex-only`를 쓰면 됩니다.
 - Gemini CLI: 0.14.0 이상(`gemini extensions` 명령 사용 가능).
 - macOS·Linux의 `bash`. (Windows는 WSL 권장 — 심링크 때문에.)
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,11 +1,11 @@
 # 설치 가이드 (Install)
 
-Humanize KR은 **Claude Code**와 **OpenAI Codex(CLI/Desktop)**, **Gemini CLI(Antigravity)** 에서 전역으로 쓸 수 있습니다.
+Humanize KR은 **Claude Code**와 **OpenAI Codex**, **Gemini CLI(Antigravity)** 에서 전역으로 쓸 수 있습니다.
 
 | 도구 | 모드 | 설치 방법 |
 |---|---|---|
 | Claude Code | Fast + strict(5인 파이프라인) | ① 플러그인 마켓플레이스(권장) / ② 클론 + `install.sh` |
-| Codex(CLI/Desktop) | Fast(단일 호출)만 | 클론 + `install.sh` |
+| Codex | Fast(단일 호출)만 | 클론 + `install.sh` |
 | Gemini CLI | Fast(단일 호출)만 | ① `gemini extensions install`(권장) / ② 클론 + `install.sh` |
 
 > Codex와 Gemini는 Claude식 다중 서브에이전트 파이프라인을 결정적으로 실행하지 못해, 단일 호출 Fast Path만 제공합니다. 정밀 검증이 필요하면 Claude Code의 `--strict`를 사용하세요.
@@ -40,9 +40,9 @@ cd im-not-ai
 
 ---
 
-## Codex(CLI/Desktop)
+## Codex
 
-Codex CLI 0.121.0 이상 또는 `~/.codex/skills`를 읽는 Desktop 버전이 필요합니다.
+Codex에서 `~/.codex/skills`를 읽는 버전이 필요합니다. CLI 사용자는 0.121.0 이상을 권장합니다.
 
 ```bash
 git clone https://github.com/epoko77-ai/im-not-ai.git
@@ -110,7 +110,7 @@ cd im-not-ai
 ## 요구 사항
 
 - Claude Code: 마켓플레이스/플러그인 지원 버전. 스크립트 설치만 할 때는 `claude` 명령이 없어도 `~/.claude`가 있거나 `--claude-only`를 쓰면 됩니다.
-- Codex: CLI 0.121.0 이상 또는 `~/.codex/skills` Skills를 지원하는 Desktop 버전. 스크립트 설치만 할 때는 `codex` 명령이 없어도 `~/.codex`가 있거나 `--codex-only`를 쓰면 됩니다.
+- Codex: `~/.codex/skills` Skills를 지원하는 버전. CLI 사용자는 0.121.0 이상을 권장합니다. 스크립트 설치만 할 때는 `codex` 명령이 없어도 `~/.codex`가 있거나 `--codex-only`를 쓰면 됩니다.
 - Gemini CLI: 0.14.0 이상(`gemini extensions` 명령 사용 가능).
 - macOS·Linux의 `bash`. (Windows는 WSL 권장 — 심링크 때문에.)
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -50,7 +50,7 @@ cd im-not-ai
 ./install.sh --codex-only
 ```
 
-`~/.codex/skills/humanize-korean`에 Fast Path 스킬을 심링크합니다. Codex에서 `$humanize-korean`으로 발동하거나, `/skills` 메뉴에서 선택하세요. `codex` 명령이 PATH에 없어도 `~/.codex`가 있거나 `--codex-only`를 쓰면 설치할 수 있습니다.
+`~/.codex/skills/humanize-korean`에 Fast Path 스킬을 심링크합니다. Codex에서 `$humanize-korean`으로 발동하거나, `/skills` 메뉴에서 선택하세요. `codex` 명령이 PATH에 없어도 `~/.codex`가 있으면 설치할 수 있습니다. `--codex-only`는 설치 대상을 Codex로만 제한합니다.
 
 ---
 
@@ -68,7 +68,7 @@ cd im-not-ai
 |---|---|
 | (없음) | `claude`·`codex`·`gemini` 명령을 자동 감지합니다. Claude/Codex는 `~/.claude`·`~/.codex` 디렉터리도 감지합니다. |
 | `--copy` | 심링크 대신 복사. 저장소를 지워도 유지(references 심링크는 실체화). ⚠ 복사본은 `uninstall.sh`가 자동 삭제하지 않음 |
-| `--claude-only` / `--codex-only` | CLI/홈 디렉터리 감지 없이 해당 스킬만 설치 |
+| `--claude-only` / `--codex-only` | 해당 대상만 설치 시도. 설치 가능 여부는 `claude`/`codex` 명령 또는 `~/.claude`/`~/.codex` 감지로 판단 |
 | `--gemini-only` | Gemini만 설치(`gemini extensions link` 실행) |
 | `--no-gemini` | Gemini 건너뜀 (Claude/Codex만) |
 | `--force` | 대상에 일반 파일/디렉토리가 있어도 `.bak.<ts>`로 백업 후 덮어씀 |
@@ -109,8 +109,8 @@ cd im-not-ai
 
 ## 요구 사항
 
-- Claude Code: 마켓플레이스/플러그인 지원 버전. 스크립트 설치만 할 때는 `claude` 명령이 없어도 `~/.claude`가 있거나 `--claude-only`를 쓰면 됩니다.
-- Codex: `~/.codex/skills` Skills를 지원하는 버전. CLI 사용자는 0.121.0 이상을 권장합니다. 스크립트 설치만 할 때는 `codex` 명령이 없어도 `~/.codex`가 있거나 `--codex-only`를 쓰면 됩니다.
+- Claude Code: 마켓플레이스/플러그인 지원 버전. 스크립트 설치는 `claude` 명령 또는 `~/.claude`가 감지될 때 진행됩니다. `--claude-only`는 설치 대상을 Claude로만 제한합니다.
+- Codex: `~/.codex/skills` Skills를 지원하는 버전. CLI 사용자는 0.121.0 이상을 권장합니다. 스크립트 설치는 `codex` 명령 또는 `~/.codex`가 감지될 때 진행됩니다. `--codex-only`는 설치 대상을 Codex로만 제한합니다.
 - Gemini CLI: 0.14.0 이상(`gemini extensions` 명령 사용 가능).
 - macOS·Linux의 `bash`. (Windows는 WSL 권장 — 심링크 때문에.)
 

--- a/install.sh
+++ b/install.sh
@@ -28,8 +28,8 @@ Usage: ./install.sh [options]
 Options:
   --copy          심링크 대신 복사(저장소를 지워도 유지, references 심링크는 실체화).
                   ※ 복사본은 uninstall.sh가 자동 삭제하지 않음(수동 삭제).
-  --claude-only   Claude만 설치(CLI/홈 디렉터리 감지 없이 강제)
-  --codex-only    Codex만 설치(CLI/홈 디렉터리 감지 없이 강제)
+  --claude-only   Claude만 설치 시도(claude 명령 또는 ~/.claude 감지 시)
+  --codex-only    Codex만 설치 시도(codex 명령 또는 ~/.codex 감지 시)
   --gemini-only   Gemini만 설치
   --no-gemini     Gemini 건너뜀 (claude/codex만)
   --force         대상에 일반 파일/디렉토리가 있어도 .bak.<ts> 백업 후 덮어씀
@@ -43,8 +43,8 @@ H
 while [ $# -gt 0 ]; do
   case "$1" in
     --copy) MODE=copy ;;
-    --claude-only) DO_CLAUDE=yes; DO_CODEX=no; DO_GEMINI=no ;;
-    --codex-only) DO_CLAUDE=no; DO_CODEX=yes; DO_GEMINI=no ;;
+    --claude-only) DO_CODEX=no; DO_GEMINI=no ;;
+    --codex-only) DO_CLAUDE=no; DO_GEMINI=no ;;
     --gemini-only) DO_CLAUDE=no; DO_CODEX=no; DO_GEMINI=yes ;;
     --no-gemini) DO_GEMINI=no ;;
     --force) FORCE=1 ;;
@@ -107,7 +107,7 @@ if [ "$DO_CLAUDE" != no ] && { [ "$DO_CLAUDE" = yes ] || has_claude_target; }; t
     install_one "$a" "$CLAUDE_HOME/agents/$(basename "$a")"
   done
 else
-  echo "== Claude Code: 건너뜀 (claude 또는 $CLAUDE_HOME 미감지 — 강제하려면 --claude-only) =="
+  echo "== Claude Code: 건너뜀 (claude 또는 $CLAUDE_HOME 미감지) =="
 fi
 
 # ---- Codex ----
@@ -116,7 +116,7 @@ if [ "$DO_CODEX" != no ] && { [ "$DO_CODEX" = yes ] || has_codex_target; }; then
   run mkdir -p "$CODEX_HOME/skills"
   install_one "$REPO/codex/skills/humanize-korean" "$CODEX_HOME/skills/humanize-korean"
 else
-  echo "== Codex: 건너뜀 (codex 또는 $CODEX_HOME 미감지 — 강제하려면 --codex-only) =="
+  echo "== Codex: 건너뜀 (codex 또는 $CODEX_HOME 미감지) =="
 fi
 
 # ---- Gemini CLI ----

--- a/install.sh
+++ b/install.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
-# Humanize KR — Claude Code + Codex CLI + Gemini CLI 전역 설치 스크립트
-# 저장소를 클론한 뒤 `./install.sh` 한 번이면 설치된 CLI(claude/codex/gemini)를 자동 감지해
-# humanize-korean 스킬(+ 에이전트)을 전역으로 연결한다. 기본은 심링크(저장소 수정 즉시 반영).
+# Humanize KR — Claude Code + Codex + Gemini CLI 전역 설치 스크립트
+# 저장소를 클론한 뒤 `./install.sh` 한 번이면 설치된 CLI 또는 Claude/Codex 홈 디렉터리를
+# 자동 감지해 humanize-korean 스킬(+ 에이전트)을 전역으로 연결한다. 기본은 심링크(저장소 수정 즉시 반영).
 set -euo pipefail
 
 REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -20,7 +20,7 @@ print_help() {
   cat <<'H'
 Usage: ./install.sh [options]
 
-  설치된 CLI를 자동 감지해 humanize-korean 스킬을 전역 설치한다.
+  설치된 CLI 또는 Claude/Codex 홈 디렉터리를 감지해 humanize-korean 스킬을 전역 설치한다.
   Claude: ~/.claude/skills/{humanize-korean,humanize,humanize-redo} + ~/.claude/agents/*.md
   Codex : ~/.codex/skills/humanize-korean
   Gemini: gemini extensions link (gemini-extension.json + GEMINI.md + commands/)
@@ -28,8 +28,8 @@ Usage: ./install.sh [options]
 Options:
   --copy          심링크 대신 복사(저장소를 지워도 유지, references 심링크는 실체화).
                   ※ 복사본은 uninstall.sh가 자동 삭제하지 않음(수동 삭제).
-  --claude-only   Claude만 설치
-  --codex-only    Codex만 설치
+  --claude-only   Claude만 설치(CLI/홈 디렉터리 감지 없이 강제)
+  --codex-only    Codex만 설치(CLI/홈 디렉터리 감지 없이 강제)
   --gemini-only   Gemini만 설치
   --no-gemini     Gemini 건너뜀 (claude/codex만)
   --force         대상에 일반 파일/디렉토리가 있어도 .bak.<ts> 백업 후 덮어씀
@@ -56,6 +56,14 @@ while [ $# -gt 0 ]; do
 done
 
 run() { echo "+ $*"; [ "$DRYRUN" = 1 ] || "$@"; }
+
+has_claude_target() {
+  command -v claude >/dev/null 2>&1 || [ -d "$CLAUDE_HOME" ]
+}
+
+has_codex_target() {
+  command -v codex >/dev/null 2>&1 || [ -d "$CODEX_HOME" ]
+}
 
 # rc: 0=대상 비었음(설치 진행) / 1=이미 우리 심링크(스킵) / 2=충돌(거부)
 prepare_target() {
@@ -89,7 +97,7 @@ install_one() {
 }
 
 # ---- Claude ----
-if [ "$DO_CLAUDE" != no ] && { [ "$DO_CLAUDE" = yes ] || command -v claude >/dev/null 2>&1; }; then
+if [ "$DO_CLAUDE" != no ] && { [ "$DO_CLAUDE" = yes ] || has_claude_target; }; then
   echo "== Claude Code =="
   run mkdir -p "$CLAUDE_HOME/skills" "$CLAUDE_HOME/agents"
   for s in humanize-korean humanize humanize-redo; do
@@ -99,16 +107,16 @@ if [ "$DO_CLAUDE" != no ] && { [ "$DO_CLAUDE" = yes ] || command -v claude >/dev
     install_one "$a" "$CLAUDE_HOME/agents/$(basename "$a")"
   done
 else
-  echo "== Claude Code: 건너뜀 (claude 미감지 — 강제하려면 --claude-only) =="
+  echo "== Claude Code: 건너뜀 (claude 또는 $CLAUDE_HOME 미감지 — 강제하려면 --claude-only) =="
 fi
 
 # ---- Codex ----
-if [ "$DO_CODEX" != no ] && { [ "$DO_CODEX" = yes ] || command -v codex >/dev/null 2>&1; }; then
-  echo "== Codex CLI =="
+if [ "$DO_CODEX" != no ] && { [ "$DO_CODEX" = yes ] || has_codex_target; }; then
+  echo "== Codex =="
   run mkdir -p "$CODEX_HOME/skills"
   install_one "$REPO/codex/skills/humanize-korean" "$CODEX_HOME/skills/humanize-korean"
 else
-  echo "== Codex CLI: 건너뜀 (codex 미감지 — 강제하려면 --codex-only) =="
+  echo "== Codex: 건너뜀 (codex 또는 $CODEX_HOME 미감지 — 강제하려면 --codex-only) =="
 fi
 
 # ---- Gemini CLI ----

--- a/install.sh
+++ b/install.sh
@@ -43,8 +43,8 @@ H
 while [ $# -gt 0 ]; do
   case "$1" in
     --copy) MODE=copy ;;
-    --claude-only) DO_CODEX=no; DO_GEMINI=no ;;
-    --codex-only) DO_CLAUDE=no; DO_GEMINI=no ;;
+    --claude-only) DO_CLAUDE=yes; DO_CODEX=no; DO_GEMINI=no ;;
+    --codex-only) DO_CLAUDE=no; DO_CODEX=yes; DO_GEMINI=no ;;
     --gemini-only) DO_CLAUDE=no; DO_CODEX=no; DO_GEMINI=yes ;;
     --no-gemini) DO_GEMINI=no ;;
     --force) FORCE=1 ;;

--- a/tests/test_install_flags.sh
+++ b/tests/test_install_flags.sh
@@ -30,13 +30,27 @@ assert_not_contains() {
 }
 
 codex_output="$(run_installer --codex-only)"
-assert_contains "$codex_output" "== Codex CLI =="
+assert_contains "$codex_output" "== Codex =="
 assert_contains "$codex_output" "+ ln -s $ROOT/codex/skills/humanize-korean $TMP_HOME/.codex/skills/humanize-korean"
-assert_not_contains "$codex_output" "Codex CLI: "
+assert_not_contains "$codex_output" "Codex: "
 
 claude_output="$(run_installer --claude-only)"
 assert_contains "$claude_output" "== Claude Code =="
 assert_contains "$claude_output" "+ ln -s $ROOT/.claude/skills/humanize-korean $TMP_HOME/.claude/skills/humanize-korean"
 assert_not_contains "$claude_output" "Claude Code: "
+
+mkdir -p "$TMP_HOME/.codex"
+codex_desktop_output="$(run_installer)"
+assert_contains "$codex_desktop_output" "== Codex =="
+assert_contains "$codex_desktop_output" "+ ln -s $ROOT/codex/skills/humanize-korean $TMP_HOME/.codex/skills/humanize-korean"
+assert_not_contains "$codex_desktop_output" "Codex: "
+rm -rf "$TMP_HOME/.codex"
+
+mkdir -p "$TMP_HOME/.claude"
+claude_desktop_output="$(run_installer)"
+assert_contains "$claude_desktop_output" "== Claude Code =="
+assert_contains "$claude_desktop_output" "+ ln -s $ROOT/.claude/skills/humanize-korean $TMP_HOME/.claude/skills/humanize-korean"
+assert_not_contains "$claude_desktop_output" "Claude Code: "
+rm -rf "$TMP_HOME/.claude"
 
 echo "install flag tests passed"

--- a/tests/test_install_flags.sh
+++ b/tests/test_install_flags.sh
@@ -29,15 +29,27 @@ assert_not_contains() {
   fi
 }
 
+codex_without_target_output="$(run_installer --codex-only)"
+assert_contains "$codex_without_target_output" "== Codex: 건너뜀"
+assert_not_contains "$codex_without_target_output" "+ ln -s $ROOT/codex/skills/humanize-korean"
+
+mkdir -p "$TMP_HOME/.codex"
 codex_output="$(run_installer --codex-only)"
 assert_contains "$codex_output" "== Codex =="
 assert_contains "$codex_output" "+ ln -s $ROOT/codex/skills/humanize-korean $TMP_HOME/.codex/skills/humanize-korean"
 assert_not_contains "$codex_output" "Codex: "
+rm -rf "$TMP_HOME/.codex"
 
+claude_without_target_output="$(run_installer --claude-only)"
+assert_contains "$claude_without_target_output" "== Claude Code: 건너뜀"
+assert_not_contains "$claude_without_target_output" "+ ln -s $ROOT/.claude/skills/humanize-korean"
+
+mkdir -p "$TMP_HOME/.claude"
 claude_output="$(run_installer --claude-only)"
 assert_contains "$claude_output" "== Claude Code =="
 assert_contains "$claude_output" "+ ln -s $ROOT/.claude/skills/humanize-korean $TMP_HOME/.claude/skills/humanize-korean"
 assert_not_contains "$claude_output" "Claude Code: "
+rm -rf "$TMP_HOME/.claude"
 
 mkdir -p "$TMP_HOME/.codex"
 codex_desktop_output="$(run_installer)"

--- a/tests/test_install_flags.sh
+++ b/tests/test_install_flags.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TMP_HOME="$(mktemp -d)"
+trap 'rm -rf "$TMP_HOME"' EXIT
+
+MINIMAL_PATH="/usr/bin:/bin:/usr/sbin:/sbin"
+
+run_installer() {
+  env -i HOME="$TMP_HOME" PATH="$MINIMAL_PATH" bash "$ROOT/install.sh" "$@" --dry-run
+}
+
+assert_contains() {
+  local output="$1" expected="$2"
+  if [[ "$output" != *"$expected"* ]]; then
+    printf 'expected output to contain: %s\n' "$expected" >&2
+    printf 'actual output:\n%s\n' "$output" >&2
+    exit 1
+  fi
+}
+
+assert_not_contains() {
+  local output="$1" unexpected="$2"
+  if [[ "$output" == *"$unexpected"* ]]; then
+    printf 'expected output not to contain: %s\n' "$unexpected" >&2
+    printf 'actual output:\n%s\n' "$output" >&2
+    exit 1
+  fi
+}
+
+codex_output="$(run_installer --codex-only)"
+assert_contains "$codex_output" "== Codex CLI =="
+assert_contains "$codex_output" "+ ln -s $ROOT/codex/skills/humanize-korean $TMP_HOME/.codex/skills/humanize-korean"
+assert_not_contains "$codex_output" "Codex CLI: "
+
+claude_output="$(run_installer --claude-only)"
+assert_contains "$claude_output" "== Claude Code =="
+assert_contains "$claude_output" "+ ln -s $ROOT/.claude/skills/humanize-korean $TMP_HOME/.claude/skills/humanize-korean"
+assert_not_contains "$claude_output" "Claude Code: "
+
+echo "install flag tests passed"


### PR DESCRIPTION
## 요약
- `--claude-only`와 `--codex-only`는 설치 대상을 하나로 좁히되, 실제 설치 여부는 `claude`/`codex` 명령이나 `~/.claude`/`~/.codex` 감지 결과로 판단하게 했습니다.
- 기본 `./install.sh` 실행도 CLI 명령뿐 아니라 `~/.claude`, `~/.codex` 디렉터리를 함께 확인합니다. CLI 없이 앱만 쓰는 사용자도 기존 홈 디렉터리가 있으면 스킬을 연결할 수 있습니다.
- Codex 관련 출력과 설치 문서에서 CLI 전용처럼 읽히는 표현을 줄였습니다.
- 최소 PATH 환경에서 only 옵션, 홈 디렉터리 없음, 홈 디렉터리 감지 흐름을 확인하는 shell 회귀 테스트를 추가했습니다.

## 원인
기존 installer는 기본 자동 감지에서 CLI 바이너리만 확인했습니다. 그래서 `~/.claude`나 `~/.codex`가 이미 있는 환경에서도 설치를 건너뛸 수 있었습니다. 이후 패치에서 only 옵션 설명이 감지 조건을 건너뛰는 강제 설치처럼 읽힐 여지가 생겨, only 옵션은 대상만 제한하고 설치 가능 조건은 기존 자동 감지와 같도록 바로잡았습니다.

## 검증
- 통과: `bash tests/test_install_flags.sh && bash -n install.sh tests/test_install_flags.sh && git diff --check`
- 통과: `./install.sh --codex-only`