### PR TITLE
fix(metrics_v2): resolve v1 metrics via sibling import

### DIFF
--- a/.claude/skills/humanize-korean/references/metrics_v2.py
+++ b/.claude/skills/humanize-korean/references/metrics_v2.py
@@ -16,8 +16,9 @@ Versioning:
   redefine them here. Regression-safe.
 - v2.0 adds 14 NEW pure functions for post-editese + T1~T8 detection.
 
-This file lives in `_workspace/v2.0-YYYY-MM-DD/03_metrics/`. Phase 6
-integrator will merge it into the project's references/metrics.py.
+This file ships in `references/` alongside metrics.py (v1.6), from which it
+re-exports the 8 base metrics via a sibling import. Phase 6 integrator will
+fold it into metrics.py.
 
 CLI:
     python metrics_v2.py --input run/01_input.txt \
@@ -40,13 +41,13 @@ from typing import Any
 # Import v1.6 metrics module (regression-safe — signatures untouched)
 # ---------------------------------------------------------------------------
 
+# metrics.py(v1.6)는 이 파일과 같은 references/ 디렉터리에 있다. 자기 디렉터리를
+# sys.path에 넣어 sibling import를 보장한다 — cwd/import 방식과 무관하게 견고.
+# (과거엔 _workspace 스테이징 위치 기준 상대경로여서 references/로 옮긴 뒤 깨졌고,
+#  references/가 이미 sys.path에 있을 때만 우연히 import되던 잠재 버그였음.)
 _HERE = os.path.dirname(os.path.abspath(__file__))
-_PROJECT_ROOT = os.path.abspath(os.path.join(_HERE, "..", "..", ".."))
-_V1_METRICS_DIR = os.path.join(
-    _PROJECT_ROOT, ".claude", "skills", "humanize-korean", "references"
-)
-if _V1_METRICS_DIR not in sys.path:
-    sys.path.insert(0, _V1_METRICS_DIR)
+if _HERE not in sys.path:
+    sys.path.insert(0, _HERE)
 
 import metrics as _v1  # noqa: E402  (sys.path mutation is intentional)
 

--- a/tests/test_metrics_v2_import.py
+++ b/tests/test_metrics_v2_import.py
@@ -1,0 +1,55 @@
+"""metrics_v2.py import-path 회귀 테스트.
+
+metrics_v2 는 v1.6 metrics.py 를 sibling import 한다. 과거 이 경로가 스테이징
+위치(`_workspace/…/03_metrics`) 기준으로 계산돼 references/ 로 옮긴 뒤엔
+`.claude/.claude/…` 로 깨져 있었고, references/ 가 이미 sys.path 에 있을 때만
+우연히 import 되던 잠재 버그였다.
+
+이 테스트는 references/ 를 sys.path 에 넣지 않고 metrics_v2.py 를 **파일 경로로
+직접 로드**해, v2 가 스스로 sibling metrics.py 를 찾는지 검증한다. (버그가 살아
+있으면 서브프로세스가 ModuleNotFoundError 로 죽어 테스트 실패.)
+"""
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import textwrap
+import unittest
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+_REPO_ROOT = os.path.abspath(os.path.join(_HERE, ".."))
+_V2 = os.path.join(
+    _REPO_ROOT, ".claude", "skills", "humanize-korean", "references", "metrics_v2.py"
+)
+
+
+class MetricsV2ImportTests(unittest.TestCase):
+    def test_v2_self_resolves_v1_metrics(self) -> None:
+        # cwd 를 레포 루트로 둬서 cwd-on-path 로도 references/ 가 안 잡히게 한다.
+        # 따라서 `import metrics` 가 되려면 metrics_v2 가 스스로 자기 디렉터리를
+        # sys.path 에 넣어야만 한다 (= 이 회귀 테스트가 지키려는 동작).
+        code = textwrap.dedent(
+            f"""
+            import importlib.util
+            spec = importlib.util.spec_from_file_location("metrics_v2_probe", {_V2!r})
+            m = importlib.util.module_from_spec(spec)
+            spec.loader.exec_module(m)
+            assert m.VERSION == "v2.0", m.VERSION
+            assert m.conclusion_pivot_count("결론적으로 그러므로") == 2   # 재export된 v1 함수
+            assert m.double_passive_count("잊혀진 사실이 되어진다") >= 1  # v2 신규 함수
+            print("OK")
+            """
+        )
+        proc = subprocess.run(
+            [sys.executable, "-c", code],
+            cwd=_REPO_ROOT,
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(proc.returncode, 0, f"metrics_v2 self-import 실패:\n{proc.stderr}")
+        self.assertIn("OK", proc.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 문제
`references/metrics_v2.py`는 v1.6 `metrics.py`를 import하는데, 그 경로가 스테이징 위치(`_workspace/…/03_metrics/`) 기준 상대경로(`../../..`)로 하드코딩돼 있었습니다. 파일이 `references/`로 옮겨진 현재는 `_V1_METRICS_DIR`가 `…/.claude/.claude/skills/…`(중복 `.claude`)로 계산돼 **존재하지 않는 경로**입니다.

지금까지 드러나지 않은 이유: `references/`가 이미 `sys.path`에 있을 때(테스트가 직접 넣거나 스크립트로 직접 실행할 때)만 우연히 `import metrics`가 옆 파일을 주워왔기 때문입니다. import 방식이 바뀌면 깨지는 잠재 버그입니다.

재현(수정 전) — `references/`를 path에 넣지 않고 파일 경로로 로드:
```
$ cd <repo root>
$ python3 -c "import importlib.util as u; s=u.spec_from_file_location('m','.claude/skills/humanize-korean/references/metrics_v2.py'); mod=u.module_from_spec(s); s.loader.exec_module(mod)"
ModuleNotFoundError: No module named 'metrics'
```

## 수정
v1 `metrics.py`는 `metrics_v2.py`와 같은 `references/` 디렉터리의 **sibling**이므로, 자기 디렉터리(`_HERE`)를 `sys.path`에 넣어 import하도록 변경했습니다. cwd·import 방식과 무관하게 동작합니다. 낡은 docstring(`_workspace` 위치 언급)도 현행화했습니다.

## 회귀 테스트
`tests/test_metrics_v2_import.py` 추가 — `references/`를 path에 넣지 않고 `metrics_v2.py`를 파일 경로로 로드해 self-resolve를 검증합니다(수정 전엔 `ModuleNotFoundError`로 실패, 수정 후 통과). baseline 파일에 의존하지 않아 fresh clone에서도 green.

## 참고 (이 PR 범위 밖)
- 기존 `tests/test_metrics.py`·`test_metrics_v2.py`의 일부 케이스는 gitignore된 baseline 픽스처(`_workspace/v1.6-*/02_katfish_baseline.json`)를 하드코딩 참조해 fresh clone에서 `FileNotFoundError`로 실패합니다. 본 PR과 무관한 기존 환경 이슈이며, 본 PR의 변경/신규 테스트는 baseline에 의존하지 않습니다.
- `metrics_v2._default_baseline_v2_path()`가 `baseline_v2_diff.json`을 가리키는데 저장소엔 `baseline_v2.json`이 있어, 기본값으로는 v2 baseline이 로드되지 않습니다(코드가 없으면 `{}`로 graceful fallback). 파일명 의도 확인이 필요해 이 PR에선 손대지 않았습니다.
