### PR TITLE
fix(install): CLI 없이 앱만 설치한 사용자 감지 (PR #35 흡수)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -28,8 +28,8 @@ Usage: ./install.sh [options]
 Options:
   --copy          심링크 대신 복사(저장소를 지워도 유지, references 심링크는 실체화).
                   ※ 복사본은 uninstall.sh가 자동 삭제하지 않음(수동 삭제).
-  --claude-only   Claude만 설치
-  --codex-only    Codex만 설치
+  --claude-only   Claude만 설치 시도(claude 명령 또는 ~/.claude 감지 시)
+  --codex-only    Codex만 설치 시도(codex 명령 또는 ~/.codex 감지 시)
   --gemini-only   Gemini만 설치
   --no-gemini     Gemini 건너뜀 (claude/codex만)
   --force         대상에 일반 파일/디렉토리가 있어도 .bak.<ts> 백업 후 덮어씀
@@ -88,8 +88,12 @@ install_one() {
   echo "installed: $dest"
 }
 
+# CLI 명령 또는 홈 디렉터리(앱만 설치한 사용자)로 대상 감지
+has_claude_target() { command -v claude >/dev/null 2>&1 || [ -d "$CLAUDE_HOME" ]; }
+has_codex_target()  { command -v codex  >/dev/null 2>&1 || [ -d "$CODEX_HOME" ]; }
+
 # ---- Claude ----
-if [ "$DO_CLAUDE" != no ] && { [ "$DO_CLAUDE" = yes ] || command -v claude >/dev/null 2>&1; }; then
+if [ "$DO_CLAUDE" != no ] && { [ "$DO_CLAUDE" = yes ] || has_claude_target; }; then
   echo "== Claude Code =="
   run mkdir -p "$CLAUDE_HOME/skills" "$CLAUDE_HOME/agents"
   for s in humanize-korean humanize humanize-redo; do
@@ -99,16 +103,16 @@ if [ "$DO_CLAUDE" != no ] && { [ "$DO_CLAUDE" = yes ] || command -v claude >/dev
     install_one "$a" "$CLAUDE_HOME/agents/$(basename "$a")"
   done
 else
-  echo "== Claude Code: 건너뜀 (claude 미감지 — 강제하려면 --claude-only) =="
+  echo "== Claude Code: 건너뜀 (claude 또는 $CLAUDE_HOME 미감지) =="
 fi
 
 # ---- Codex ----
-if [ "$DO_CODEX" != no ] && { [ "$DO_CODEX" = yes ] || command -v codex >/dev/null 2>&1; }; then
-  echo "== Codex CLI =="
+if [ "$DO_CODEX" != no ] && { [ "$DO_CODEX" = yes ] || has_codex_target; }; then
+  echo "== Codex =="
   run mkdir -p "$CODEX_HOME/skills"
   install_one "$REPO/codex/skills/humanize-korean" "$CODEX_HOME/skills/humanize-korean"
 else
-  echo "== Codex CLI: 건너뜀 (codex 미감지 — 강제하려면 --codex-only) =="
+  echo "== Codex: 건너뜀 (codex 또는 $CODEX_HOME 미감지) =="
 fi
 
 # ---- Gemini CLI ----

--- a/tests/test_install_flags.sh
+++ b/tests/test_install_flags.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TMP_HOME="$(mktemp -d)"
+trap 'rm -rf "$TMP_HOME"' EXIT
+
+MINIMAL_PATH="/usr/bin:/bin:/usr/sbin:/sbin"
+
+run_installer() {
+  env -i HOME="$TMP_HOME" PATH="$MINIMAL_PATH" bash "$ROOT/install.sh" "$@" --dry-run
+}
+
+assert_contains() {
+  local output="$1" expected="$2"
+  if [[ "$output" != *"$expected"* ]]; then
+    printf 'expected output to contain: %s\n' "$expected" >&2
+    printf 'actual output:\n%s\n' "$output" >&2
+    exit 1
+  fi
+}
+
+assert_not_contains() {
+  local output="$1" unexpected="$2"
+  if [[ "$output" == *"$unexpected"* ]]; then
+    printf 'expected output not to contain: %s\n' "$unexpected" >&2
+    printf 'actual output:\n%s\n' "$output" >&2
+    exit 1
+  fi
+}
+
+codex_without_target_output="$(run_installer --codex-only)"
+assert_contains "$codex_without_target_output" "== Codex: 건너뜀"
+assert_not_contains "$codex_without_target_output" "+ ln -s $ROOT/codex/skills/humanize-korean"
+
+mkdir -p "$TMP_HOME/.codex"
+codex_output="$(run_installer --codex-only)"
+assert_contains "$codex_output" "== Codex =="
+assert_contains "$codex_output" "+ ln -s $ROOT/codex/skills/humanize-korean $TMP_HOME/.codex/skills/humanize-korean"
+assert_not_contains "$codex_output" "Codex: "
+rm -rf "$TMP_HOME/.codex"
+
+claude_without_target_output="$(run_installer --claude-only)"
+assert_contains "$claude_without_target_output" "== Claude Code: 건너뜀"
+assert_not_contains "$claude_without_target_output" "+ ln -s $ROOT/.claude/skills/humanize-korean"
+
+mkdir -p "$TMP_HOME/.claude"
+claude_output="$(run_installer --claude-only)"
+assert_contains "$claude_output" "== Claude Code =="
+assert_contains "$claude_output" "+ ln -s $ROOT/.claude/skills/humanize-korean $TMP_HOME/.claude/skills/humanize-korean"
+assert_not_contains "$claude_output" "Claude Code: "
+rm -rf "$TMP_HOME/.claude"
+
+mkdir -p "$TMP_HOME/.codex"
+codex_desktop_output="$(run_installer)"
+assert_contains "$codex_desktop_output" "== Codex =="
+assert_contains "$codex_desktop_output" "+ ln -s $ROOT/codex/skills/humanize-korean $TMP_HOME/.codex/skills/humanize-korean"
+assert_not_contains "$codex_desktop_output" "Codex: "
+rm -rf "$TMP_HOME/.codex"
+
+mkdir -p "$TMP_HOME/.claude"
+claude_desktop_output="$(run_installer)"
+assert_contains "$claude_desktop_output" "== Claude Code =="
+assert_contains "$claude_desktop_output" "+ ln -s $ROOT/.claude/skills/humanize-korean $TMP_HOME/.claude/skills/humanize-korean"
+assert_not_contains "$claude_desktop_output" "Claude Code: "
+rm -rf "$TMP_HOME/.claude"
+
+echo "install flag tests passed"


### PR DESCRIPTION
install.sh가 CLI PATH에만 의존해 앱만 쓰는 사용자를 조용히 건너뛰던 버그 수정. 홈 디렉터리(~/.claude·~/.codex) 감지 추가 + 회귀 테스트.

원 기여: @chizcake (#35). v2.1 리베이스하며 install.sh 로직·문구만 흡수.

https://claude.ai/code/session_01GtqmNmSdC4KXnXZEsjSS5W