### PR TITLE
fix(install): 에이전트 전역 설치를 런타임 4종으로 한정

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,9 @@
 _workspace/
 _workspace_prev/
 
+# install.sh가 생성하는 저장소 로컬 에이전트 링크 (원본은 agents/)
+.claude/agents/
+
 # macOS
 .DS_Store
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -36,7 +36,7 @@ cd im-not-ai
 ./install.sh --claude-only
 ```
 
-`~/.claude/skills/`에 스킬 3개, `~/.claude/agents/`에 에이전트 9개를 **심링크**합니다(저장소를 수정하면 즉시 반영). 새 세션에서 `/humanize-korean`.
+`~/.claude/skills/`에 스킬 3개, `~/.claude/agents/`에 **런타임 에이전트 4개**(monolith·diagnostician·finalizer·taxonomist)를 **심링크**합니다(저장소를 수정하면 즉시 반영). 릴리스 회차 전용 개발 도구 5개(distiller·scholar·gap-analyzer·metric-engineer·rules-integrator)는 저장소 내부 `.claude/agents/`에만 연결되어 **이 저장소에서 연 세션에서만** 로드됩니다 — 전역 에이전트 description이 무관한 프로젝트 세션의 컨텍스트를 차지하지 않게 하기 위한 분리입니다(Claude 5 세대 컨텍스트 엔지니어링 권고). 새 세션에서 `/humanize-korean`.
 
 ---
 
@@ -104,7 +104,7 @@ cd im-not-ai
 - **"refuse: … 가 이미 있음"** — 해당 경로에 이미 다른 파일/링크가 있습니다. `--force`(백업 후 덮어쓰기) 또는 직접 정리 후 재실행하세요.
 - **스킬이 안 보임** — Claude는 **새 세션**에서 로드됩니다. `claude plugin list`(마켓플레이스 설치) 또는 `ls -l ~/.claude/skills`(스크립트 설치)로 확인하세요. Codex는 `/skills` 메뉴로 확인.
 - **저장소 위치 이동/삭제** — 심링크 설치는 클론한 저장소 경로에 의존합니다. 저장소를 옮기면 `./uninstall.sh`(옛 경로) 후 새 경로에서 `./install.sh`를 다시 실행하거나, 위치 비의존이 필요하면 `--copy`로 설치하세요.
-- **레포 기여 개발** — 이 저장소는 에이전트를 플러그인 컨벤션(`agents/`)에, 스킬을 `.claude/skills/`에 둡니다. 저장소 안에서 직접 테스트하려면 `./install.sh`로 한 번 전역 연결한 뒤(에이전트가 `~/.claude/agents`에서 탐색됨) 사용하세요.
+- **레포 기여 개발** — 이 저장소는 에이전트 원본을 플러그인 컨벤션(`agents/`)에, 스킬을 `.claude/skills/`에 둡니다. `./install.sh`를 한 번 실행하면 런타임 에이전트 4개는 `~/.claude/agents`에, 릴리스 회차 전용 개발 도구 5개는 저장소 `.claude/agents/`에 연결되므로, **저장소 루트에서 연 세션에서는 9종 전부** 사용할 수 있습니다. (구버전으로 전역 설치했던 개발 전용·은퇴 에이전트 링크는 재실행 시 자동 해제됩니다.)
 
 ## 요구 사항
 

--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ Claude Code에서는 세 가지 방법 중 편한 쪽으로 사용합니다. Cod
 /plugin install humanize-korean@im-not-ai
 ```
 
-스킬 3개 + 서브에이전트 9개가 함께 설치됩니다. 자세한 옵션·스크립트 설치는 [설치](#설치-install) 섹션과 [`INSTALL.md`](INSTALL.md) 참고. (초기 패키징을 탐색한 [`gaebalai/im-not-ai`](https://github.com/gaebalai/im-not-ai) 포크도 있습니다.)
+스킬 3개 + 서브에이전트 9개가 함께 설치됩니다. (스크립트 설치 `./install.sh`는 전역엔 런타임 에이전트 4개만 연결하고 릴리스 회차 전용 개발 도구 5개는 저장소 로컬로 분리합니다 — [`INSTALL.md`](INSTALL.md) 참고.) 자세한 옵션·스크립트 설치는 [설치](#설치-install) 섹션과 [`INSTALL.md`](INSTALL.md) 참고. (초기 패키징을 탐색한 [`gaebalai/im-not-ai`](https://github.com/gaebalai/im-not-ai) 포크도 있습니다.)
 
 **방법 D — Codex CLI (공식, 단일 콜 경로)**
 

--- a/install.sh
+++ b/install.sh
@@ -16,12 +16,19 @@ FORCE=0
 DRYRUN=0
 TS="$(date +%Y%m%d-%H%M%S)"
 
+# 에이전트 이원화: 스킬이 런타임에 호출하는 4종만 전역(~/.claude/agents)으로 연결하고,
+# 릴리스 회차 전용 개발 도구 5종은 저장소 로컬(.claude/agents)에만 연결한다.
+# 전역 에이전트 description은 모든 프로젝트의 모든 세션에 상시 로드되므로, 여기 목록에
+# 추가하는 것은 SKILL.md가 실제로 호출하는 에이전트로 한정할 것.
+RUNTIME_AGENTS="humanize-monolith humanize-diagnostician humanize-finalizer korean-ai-tell-taxonomist"
+
 print_help() {
   cat <<'H'
 Usage: ./install.sh [options]
 
   설치된 CLI를 자동 감지해 humanize-korean 스킬을 전역 설치한다.
-  Claude: ~/.claude/skills/{humanize-korean,humanize,humanize-redo} + ~/.claude/agents/*.md
+  Claude: ~/.claude/skills/{humanize-korean,humanize,humanize-redo} + 런타임 에이전트 4종(~/.claude/agents)
+          개발 전용 에이전트 5종은 저장소 내부 .claude/agents 에만 연결(저장소에서 연 세션에서만 로드)
   Codex : ~/.codex/skills/humanize-korean
   Gemini: gemini extensions link (gemini-extension.json + GEMINI.md + commands/)
 
@@ -100,7 +107,28 @@ if [ "$DO_CLAUDE" != no ] && { [ "$DO_CLAUDE" = yes ] || has_claude_target; }; t
     install_one "$REPO/.claude/skills/$s" "$CLAUDE_HOME/skills/$s"
   done
   for a in "$REPO/agents"/*.md; do
-    install_one "$a" "$CLAUDE_HOME/agents/$(basename "$a")"
+    name="$(basename "$a" .md)"
+    case " $RUNTIME_AGENTS " in
+      *" $name "*)
+        install_one "$a" "$CLAUDE_HOME/agents/$name.md"
+        ;;
+      *)
+        install_one "$a" "$REPO/.claude/agents/$name.md"
+        # 구버전(에이전트 전원 전역) 설치 마이그레이션: 우리 저장소를 가리키는 전역 링크만 해제
+        legacy="$CLAUDE_HOME/agents/$name.md"
+        if [ -L "$legacy" ] && [ "$(readlink "$legacy")" = "$a" ]; then
+          echo "+ rm $legacy (개발 전용 — 전역 해제)"; [ "$DRYRUN" = 1 ] || rm "$legacy"
+        fi
+        ;;
+    esac
+  done
+  # 은퇴 에이전트 마이그레이션: 우리 저장소를 가리키지만 원본이 사라진 링크 해제 (v2.1 은퇴 5종 등)
+  for legacy in "$CLAUDE_HOME/agents"/*.md "$REPO/.claude/agents"/*.md; do
+    [ -L "$legacy" ] || continue
+    tgt="$(readlink "$legacy")"
+    case "$tgt" in
+      "$REPO/agents/"*) [ -e "$tgt" ] || { echo "+ rm $legacy (은퇴 에이전트 — 원본 없음)"; [ "$DRYRUN" = 1 ] || rm "$legacy"; } ;;
+    esac
   done
 else
   echo "== Claude Code: 건너뜀 (claude 또는 $CLAUDE_HOME 미감지) =="

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -30,7 +30,16 @@ for s in humanize-korean humanize humanize-redo; do
 done
 remove_if_ours "$CODEX_HOME/skills/humanize-korean" "$REPO/codex/skills/humanize-korean"
 for a in "$REPO/agents"/*.md; do
-  remove_if_ours "$CLAUDE_HOME/agents/$(basename "$a")" "$a"
+  remove_if_ours "$CLAUDE_HOME/agents/$(basename "$a")" "$a"   # 전역(런타임 4종 + 구버전 전원 설치 잔여)
+  remove_if_ours "$REPO/.claude/agents/$(basename "$a")" "$a"  # 저장소 로컬(개발 전용 5종)
+done
+# 은퇴 에이전트 잔여: 우리 저장소를 가리키지만 원본이 사라진 링크도 제거
+for legacy in "$CLAUDE_HOME/agents"/*.md "$REPO/.claude/agents"/*.md; do
+  [ -L "$legacy" ] || continue
+  tgt="$(readlink "$legacy")"
+  case "$tgt" in
+    "$REPO/agents/"*) [ -e "$tgt" ] || { echo "+ rm $legacy (은퇴 에이전트)"; [ "$DRYRUN" = 1 ] || rm "$legacy"; } ;;
+  esac
 done
 
 # ---- Gemini CLI ----


### PR DESCRIPTION
## 무엇을

`install.sh`가 `agents/*.md` 전부를 `~/.claude/agents`(전역)에 심링크하던 것을 이원화합니다.

- **전역 유지 (4, 런타임)**: humanize-monolith · humanize-diagnostician · humanize-finalizer · korean-ai-tell-taxonomist — SKILL.md가 실제 호출하는 에이전트 (README v2.2 「에이전트 구성」 표와 동일)
- **저장소 로컬 (5, 릴리스 회차 전용 개발 도구)**: translationese-research-distiller · korean-translation-scholar · taxonomy-gap-analyzer · post-editese-metric-engineer · quick-rules-integrator → `$REPO/.claude/agents/`에만 연결, 저장소에서 연 세션에서만 로드

## 왜

전역 에이전트의 description은 **모든 프로젝트의 모든 세션**에 상시 로드됩니다. 개발 도구 5종은 README 스스로 "윤문 실행과 무관"이라고 명시하는데도 무관한 세션의 컨텍스트를 차지해 왔습니다. Claude 5 세대 컨텍스트 엔지니어링 권고(점진적 공개)에 따라 상시 로드를 실제 호출되는 것으로 한정합니다. 참고: [The New Rules of Context Engineering for Claude 5 Models](https://claude.com/blog/the-new-rules-of-context-engineering-for-claude-5-generation-models)

## 마이그레이션 (재실행 한 번이면 자동)

구버전 설치자는 `./update.sh`(또는 `./install.sh` 재실행) 한 번이면 됩니다:
1. **개발 도구 전역 링크 해제** — 우리 저장소를 가리키는 링크만(사용자가 직접 둔 파일·다른 링크는 불변)
2. **은퇴 에이전트 dangling 링크 해제** — v2.1에서 은퇴한 5종(detector·rewriter·reviewer·auditor·web-architect)의 전역 링크는 원본이 사라져 dangling으로 남는데, 이것도 자동 정리합니다 (이번 패치 전에는 정리 경로가 없었음)

`uninstall.sh`도 저장소 로컬 링크·은퇴 잔여 링크까지 제거하도록 확장.

## 검증

격리된 `CLAUDE_HOME`에서 확인:
1. 신규 설치 → 전역에 런타임 4종만 생성 ✓
2. 구버전 재현(개발 도구 전역 링크 + 은퇴 dangling 링크) 후 재실행 → 둘 다 자동 해제, 런타임 4종만 잔존 ✓
3. `uninstall.sh --dry-run` → 전역 + 저장소 로컬 전부 제거 대상 표시 ✓

`bash -n` 통과, 재실행 멱등성 확인. v2.3.0 (`53e24e8`) 위로 리베이스 완료.

🤖 Generated with [Claude Code](https://claude.com/claude-code)