### PR TITLE
chore(release): 배포 매니페스트 버전 드리프트 정정 + 동기화 테스트

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,15 +5,15 @@
   },
   "metadata": {
     "description": "AI가 쓴 한글 텍스트를 사람이 쓴 글처럼 윤문하는 humanize-korean 스킬 마켓플레이스",
-    "version": "2.1.0",
+    "version": "2.3.0",
     "pluginRoot": "."
   },
   "plugins": [
     {
       "name": "humanize-korean",
       "source": "./",
-      "description": "AI가 쓴 한글 텍스트를 사람이 쓴 글처럼 윤문하는 오케스트레이터 스킬 + 서브에이전트 묶음 (Fast + strict).",
-      "version": "2.1.0",
+      "description": "AI가 쓴 한글 텍스트를 사람이 쓴 글처럼 윤문하는 오케스트레이터 스킬 + 서브에이전트 묶음 (route_hint 3경로).",
+      "version": "2.3.0",
       "keywords": ["korean", "humanize", "ai-detector", "윤문", "번역투"]
     }
   ]

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "humanize-korean",
-  "version": "2.1.0",
-  "description": "AI가 쓴 한글 텍스트를 사람이 쓴 글처럼 윤문 — Fast(monolith) + strict 5인 파이프라인. 10대 카테고리 40+ AI 티 패턴 탐지·재작성.",
+  "version": "2.3.0",
+  "description": "AI가 쓴 한글 텍스트를 사람이 쓴 글처럼 윤문 — route_hint 3경로(light 1콜 · standard 2콜 · heavy 3+콜). 10대 카테고리 70 AI 티 패턴 탐지·재작성.",
   "author": {
     "name": "epoko77-ai"
   },

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -14,19 +14,25 @@ grep 전수 조사(2026-07-17, v2.0.1 기준)로 확정한 목록입니다.
 | 4 | `README.md` | 제목(H1) + "아키텍처" 헤더 | `vX.Y.Z` / `vX.Y` |
 | 5 | `README.md` | 신규 릴리스 노트 절 (`## vX.Y — …`) | 절 추가 |
 | 6 | `CLAUDE.md` | 제목(H1) | `vX.Y.Z` |
-| 7 | `.claude/commands/humanize.md` | 배너 예시 (`humanize-korean vX.Y — strict 모드 …`) | `vX.Y` |
+| 7 | `commands/humanize.toml` | 배너 예시 (`humanize-korean vX.Y — …`) | `vX.Y` |
 | 8 | `references/ai-tell-taxonomy.md` | 제목(H1) + "버전 관리" 절 | 분류 체계 버전 — 스킬 버전과 **별개 트랙**. 분류 변경이 있는 릴리스에서만 갱신 |
 | 9 | `references/quick-rules.md` | 제목(H1) | 분류 체계 버전 트랙과 동행 |
-| 10 | git tag | `vX.Y.Z` | 아래 §3 시점 규칙 준수 |
+| 10 | `.claude-plugin/plugin.json` | `version` + `description` | `"X.Y.Z"` — **마켓플레이스 설치 사용자가 보는 버전.** `tests/test_version_sync.py`가 SKILL.md와 대사 |
+| 11 | `.claude-plugin/marketplace.json` | `metadata.version` + `plugins[].version` + `plugins[].description` | `"X.Y.Z"` — 동일 테스트가 대사 |
+| 12 | git tag | `vX.Y.Z` | 아래 §3 시점 규칙 준수 |
 
-**갱신 불필요 (도입 시점 표기)**: `scripts/prepare_monolith_input.py` docstring의 "v1.6", `.claude/agents/humanize-monolith.md` description의 "v1.6.1", README의 과거 릴리스 노트 절 — 모두 그 기능이 도입된 버전의 역사 기록이므로 건드리지 않습니다. 단, **에이전트의 동작 계약(도구 호출 캡·산출물 형태)이 바뀌는 릴리스라면** 해당 에이전트 정의의 description도 함께 갱신합니다.
+**#10·#11은 사람이 기억하지 않아도 됩니다** — `tests/test_version_sync.py`가 SKILL.md frontmatter를 SSOT로 삼아 두 매니페스트를 대사하고, 어긋나면 CI에서 막습니다. description에 은퇴한 구조 표기(`5인 파이프라인` 등)가 남아 있는 경우도 같은 테스트가 잡습니다.
+
+**별개 트랙**: `gemini-extension.json` + `GEMINI.md`는 자체 룰북(패턴 47종)을 embed한 독립 배포물이라 스킬 버전과 동행하지 않습니다. 내용을 갱신하는 회차에만 함께 올립니다.
+
+**갱신 불필요 (도입 시점 표기)**: `scripts/prepare_monolith_input.py` docstring의 "v1.6", `agents/humanize-monolith.md` description의 "v1.6.1", README의 과거 릴리스 노트 절 — 모두 그 기능이 도입된 버전의 역사 기록이므로 건드리지 않습니다. 단, **에이전트의 동작 계약(도구 호출 캡·산출물 형태)이 바뀌는 릴리스라면** 해당 에이전트 정의의 description도 함께 갱신합니다.
 
 전수 확인 명령 (릴리스 브랜치에서 실행, 구버전 표기 잔존 여부 검사):
 
 ```bash
 grep -rn "v[0-9]\.[0-9]" \
   .claude/skills/humanize-korean/SKILL.md \
-  .claude/commands/ CLAUDE.md \
+  commands/ CLAUDE.md \
   | grep -v "역사\|이력\|변경 고지\|버전 요약"
 # README.md는 과거 릴리스 노트가 많으므로 제목·아키텍처 헤더만 육안 확인:
 sed -n '1,40p' README.md
@@ -34,12 +40,12 @@ sed -n '1,40p' README.md
 
 ## 2. 릴리스 전 확인 항목
 
-- [ ] **글로벌 에이전트 심링크 동기화** (에이전트를 추가·은퇴한 릴리스만): `~/.claude/agents/`는 프로젝트 `.claude/agents/*.md`로의 파일별 심링크다. 신규 에이전트는 `ln -sf`로 링크를 걸고, 은퇴한 에이전트는 죽은 링크를 `rm`한다. 링크가 없으면 세션이 그 에이전트를 로드하지 못한다(정밀 3콜이 안 돎). 확인: `ls -la ~/.claude/agents/ | grep humanize`로 링크 대상이 실재 파일인지 검사.
+- [ ] **글로벌 에이전트 심링크 동기화** (에이전트를 추가·은퇴한 릴리스만): `~/.claude/agents/`는 프로젝트 `agents/*.md`로의 파일별 심링크다. 신규 에이전트는 `ln -sf`로 링크를 걸고, 은퇴한 에이전트는 죽은 링크를 `rm`한다. 링크가 없으면 세션이 그 에이전트를 로드하지 못한다(정밀 3콜이 안 돎). 확인: `ls -la ~/.claude/agents/ | grep humanize`로 링크 대상이 실재 파일인지 검사.
 
 
 - [ ] **테스트**: `python3 -m pytest tests/ -q` 전체 통과 (pytest 미설치 환경이면 `pip install pytest` 후 실행)
 - [ ] **shim 스모크**: `python3 scripts/prepare_monolith_input.py --text "테스트 문장입니다." --genre essay` 가 `00_metrics.json` + `01_input_with_metrics.txt`를 만드는지 확인 (생성된 임시 run 디렉토리는 삭제)
-- [ ] **버전 문자열**: §1 표의 #1~#9 전수 갱신 — 특히 **SKILL.md frontmatter·배너** (과거 2회 누락 지점)
+- [ ] **버전 문자열**: §1 표의 #1~#11 전수 갱신 — 특히 **SKILL.md frontmatter·배너** (과거 2회 누락 지점). #10·#11 매니페스트는 `python3 -m pytest tests/test_version_sync.py -q`가 대사
 - [ ] **문서 정합**: 도구 호출 캡·산출물 목록(fast=`final.md` 1개, strict=`final.md`+`summary.md`)이 SKILL.md·README·CLAUDE.md·에이전트 정의에서 일치하는지
 - [ ] **발행 노트**: README에 `## vX.Y` 절 작성, 검증 결과는 실측 수치만 (추정 금지)
 - [ ] **부속물**: 썸네일·social preview 갱신이 있으면 태그 전에 머지

--- a/tests/test_version_sync.py
+++ b/tests/test_version_sync.py
@@ -1,0 +1,101 @@
+"""패키징 매니페스트 버전 동기화 — 결정적, CI에서 항상 실행.
+
+RELEASING.md는 "SKILL.md frontmatter가 런타임 SSOT"라고 못박고, 버전 문자열이
+등장하는 위치를 §1 표로 전수 관리한다. 그런데 그 표에 배포 매니페스트
+(`.claude-plugin/*.json`)가 빠져 있어 마켓플레이스 설치 사용자가 보는 버전만
+갱신 대상에서 누락돼 왔다.
+
+이 테스트는 그 누락을 사람의 체크리스트 대신 코드가 막는다 —
+`build_quick_rules.py --check`가 룰북 drift를 막는 것과 같은 방식.
+
+`python3 -m unittest` 또는 pytest 양쪽에서 동작.
+"""
+from __future__ import annotations
+
+import json
+import os
+import re
+import unittest
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+_ROOT = os.path.abspath(os.path.join(_HERE, ".."))
+_SKILL = os.path.join(_ROOT, ".claude", "skills", "humanize-korean", "SKILL.md")
+_PLUGIN = os.path.join(_ROOT, ".claude-plugin", "plugin.json")
+_MARKETPLACE = os.path.join(_ROOT, ".claude-plugin", "marketplace.json")
+
+# frontmatter의 version 한 줄. PyYAML 의존을 만들지 않기 위해 직접 뽑는다
+# (이 레포는 stdlib only).
+_VERSION_RE = re.compile(r'^version:\s*"?([0-9]+\.[0-9]+\.[0-9]+)"?\s*$', re.M)
+
+
+def _read(path: str) -> str:
+    with open(path, encoding="utf-8") as f:
+        return f.read()
+
+
+def skill_version() -> str:
+    """런타임 SSOT — SKILL.md frontmatter의 version."""
+    head = _read(_SKILL).split("---", 2)[1]
+    match = _VERSION_RE.search(head)
+    if not match:
+        raise AssertionError(f"SKILL.md frontmatter에서 version을 찾지 못함: {_SKILL}")
+    return match.group(1)
+
+
+class ManifestVersionSyncTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.expected = skill_version()
+
+    def test_plugin_json_matches_skill(self) -> None:
+        actual = json.loads(_read(_PLUGIN))["version"]
+        self.assertEqual(
+            actual,
+            self.expected,
+            f".claude-plugin/plugin.json version={actual} != SKILL.md {self.expected} "
+            f"— RELEASING.md §1 표대로 함께 갱신할 것",
+        )
+
+    def test_marketplace_metadata_matches_skill(self) -> None:
+        actual = json.loads(_read(_MARKETPLACE))["metadata"]["version"]
+        self.assertEqual(
+            actual,
+            self.expected,
+            f"marketplace.json metadata.version={actual} != SKILL.md {self.expected}",
+        )
+
+    def test_marketplace_entry_matches_skill(self) -> None:
+        entries = json.loads(_read(_MARKETPLACE))["plugins"]
+        for entry in entries:
+            with self.subTest(plugin=entry["name"]):
+                self.assertEqual(
+                    entry["version"],
+                    self.expected,
+                    f"marketplace.json plugins[{entry['name']}].version="
+                    f"{entry['version']} != SKILL.md {self.expected}",
+                )
+
+
+class ManifestDescriptionTests(unittest.TestCase):
+    """은퇴한 아키텍처를 광고하고 있지 않은지 — 마켓플레이스 노출 문구 검사."""
+
+    # v2.1에서 은퇴한 5인 파이프라인. 설치 사용자가 첫 화면에서 보는 문구라
+    # 남아 있으면 실제 동작(route_hint 3경로)과 어긋난다.
+    RETIRED_TERMS = ("5인 파이프라인", "strict 5인")
+
+    def _descriptions(self) -> list[tuple[str, str]]:
+        plugin = json.loads(_read(_PLUGIN))
+        market = json.loads(_read(_MARKETPLACE))
+        out = [("plugin.json", plugin["description"])]
+        out.append(("marketplace.json metadata", market["metadata"]["description"]))
+        out += [(f"marketplace.json {e['name']}", e["description"]) for e in market["plugins"]]
+        return out
+
+    def test_no_retired_architecture_terms(self) -> None:
+        for where, desc in self._descriptions():
+            with self.subTest(manifest=where):
+                hits = [t for t in self.RETIRED_TERMS if t in desc]
+                self.assertEqual(hits, [], f"{where}에 은퇴한 구조 표기 잔존: {hits}")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 요약

마켓플레이스로 설치하는 사용자가 보는 버전이 **2.1.0에 멈춰 있습니다.** SKILL.md frontmatter(런타임 SSOT)는 2.3.0입니다.

| 파일 | 현재 | SKILL.md |
|---|---|---|
| `.claude-plugin/plugin.json` | `2.1.0` | `2.3.0` |
| `.claude-plugin/marketplace.json` (metadata + plugins[]) | `2.1.0` | `2.3.0` |

설치 화면에 노출되는 문구도 낡아 있습니다:

```
plugin.json description:
"… Fast(monolith) + strict 5인 파이프라인. 10대 카테고리 40+ AI 티 패턴 …"
                     ^^^^^^^^^^^^^^^^^^^^                  ^^^
                     v2.1에서 은퇴                          현재 활성 70
```

## 왜 반복되는가

`RELEASING.md` §1 "버전 문자열이 등장하는 위치 (전수)" 표에 **두 매니페스트가 애초에 없습니다.** 릴리스 담당이 표대로 완벽하게 수행해도 이 두 파일은 갱신되지 않습니다.

같은 문서 첫 문단이 "`SKILL.md` 버전 갱신이 두 번 연속 누락"된 사고를 기록하고 있습니다. 표에 줄만 더하면 같은 종류의 재발을 사람의 주의력에 다시 맡기는 셈이라, 코드가 막도록 했습니다 — 이 레포가 이미 `build_quick_rules.py --check`로 룰북 drift를 막는 방식 그대로입니다.

## 변경

1. `plugin.json` · `marketplace.json` version `2.1.0` → `2.3.0`
2. 두 매니페스트 description을 route_hint 3경로 + 70패턴으로 정정
3. **`tests/test_version_sync.py` 신설**
   - SKILL.md frontmatter를 SSOT로 삼아 두 매니페스트의 `version` 대사
   - description에 은퇴 구조 표기(`5인 파이프라인` 등)가 남아 있으면 실패
   - stdlib only(프론트매터 직접 파싱 — PyYAML 의존 안 만듦), CI에서 항상 실행
4. `RELEASING.md` §1에 `#10`·`#11`로 두 매니페스트 등재 + 체크리스트에 테스트 명령 추가
5. `RELEASING.md`의 **존재하지 않는 경로 3곳** 정정
   - `.claude/commands/humanize.md` → `commands/humanize.toml`
   - `.claude/agents/humanize-monolith.md` → `agents/humanize-monolith.md`
   - grep 전수 조사 명령의 `.claude/commands/` → `commands/`

   현재 레포에 `.claude/commands/`·`.claude/agents/`는 없습니다. 릴리스 담당이 §1의 grep 명령을 그대로 실행하면 빈손이 됩니다.

## `gemini-extension.json`은 건드리지 않았습니다

버전이 `1.5.0`으로 더 낡았지만, `GEMINI.md`가 자체 룰북(패턴 ID 47종)을 embed한 독립 배포물이고 `"40+"`라는 표기가 그 내용과 서로 맞습니다. 번호만 올리면 오히려 내용과 어긋나므로, §1에 **"별개 트랙"**으로 명시만 했습니다. 내용째 v2.3으로 올릴지는 별도 판단이 필요해 보입니다.

## 검증

```
$ python3 -m pytest tests/ -q --ignore=tests/test_humanize_live.py
189 passed, 1 skipped, 16 subtests passed in 0.37s

$ python3 scripts/build_quick_rules.py --check      # exit 0
$ python3 scripts/build_diagnosis_rules.py --check  # exit 0
```

수정 전 상태에서 신규 테스트를 돌리면 4건을 정확히 지목합니다:

```
FAILED ManifestVersionSyncTests::test_plugin_json_matches_skill
FAILED ManifestVersionSyncTests::test_marketplace_metadata_matches_skill
SUBFAILED(plugin='humanize-korean') ::test_marketplace_entry_matches_skill
SUBFAILED(manifest='plugin.json') ::test_no_retired_architecture_terms
  AssertionError: ['5인 파이프라인', 'strict 5인'] != []
```

## 영향 범위

스킬 런타임 코드·에이전트 정의·분류 체계 변경 없음. 매니페스트 2 + 릴리스 문서 1 + 신규 테스트 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
