### PR TITLE
fix(install): 전역 설치를 스킬이 쓰는 에이전트 4종으로 한정

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,3 +23,6 @@ jobs:
       - run: python3 scripts/build_quick_rules.py --check
       # diagnosis-rules.md(진단 전용 슬림 인덱스)도 동일한 drift 검사.
       - run: python3 scripts/build_diagnosis_rules.py --check
+      # install.sh 플래그 동작(--dry-run 기반). pytest가 .sh 파일은 수집하지 않아
+      # 지금까지 CI에서 한 번도 실행된 적이 없다.
+      - run: bash tests/test_install_flags.sh

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -36,7 +36,9 @@ cd im-not-ai
 ./install.sh --claude-only
 ```
 
-`~/.claude/skills/`에 스킬 3개, `~/.claude/agents/`에 에이전트 9개를 **심링크**합니다(저장소를 수정하면 즉시 반영). 새 세션에서 `/humanize-korean`.
+`~/.claude/skills/`에 스킬 3개, `~/.claude/agents/`에 **스킬이 실제로 쓰는 에이전트 4개**(런타임 3 — monolith·diagnostician·finalizer, 유지보수 1 — taxonomist)를 **심링크**합니다(저장소를 수정하면 즉시 반영). 새 세션에서 `/humanize-korean`.
+
+`agents/`의 나머지 5개는 릴리스 회차용 개발 도구라 기본 설치에서 제외합니다 — 서브에이전트는 description 매칭으로 자동 라우팅되므로, 윤문과 무관한 정의가 전역 풀에 상주하면 다른 작업에서 잘못 호출될 수 있습니다. 레포 기여자처럼 전부 필요하면 `./install.sh --all-agents`.
 
 ---
 

--- a/install.sh
+++ b/install.sh
@@ -14,7 +14,14 @@ DO_CODEX=auto
 DO_GEMINI=auto
 FORCE=0
 DRYRUN=0
+ALL_AGENTS=0
 TS="$(date +%Y%m%d-%H%M%S)"
+
+# 스킬 런타임이 호출하는 3종 + 별도 명령으로만 트리거되는 유지보수 1종.
+# agents/ 의 나머지(릴리스 회차용 개발 도구)는 --all-agents 일 때만 설치한다 —
+# 서브에이전트는 description 매칭으로 자동 라우팅되므로, 윤문과 무관한 정의가
+# 전역 풀에 상주하면 다른 작업에서 잘못 호출될 수 있다.
+INSTALLED_AGENTS="humanize-monolith humanize-diagnostician humanize-finalizer korean-ai-tell-taxonomist"
 
 print_help() {
   cat <<'H'
@@ -32,6 +39,9 @@ Options:
   --codex-only    Codex만 설치 시도(codex 명령 또는 ~/.codex 감지 시)
   --gemini-only   Gemini만 설치
   --no-gemini     Gemini 건너뜀 (claude/codex만)
+  --all-agents    agents/ 전체를 전역 설치(개발용 1회성 정의 포함).
+                  기본은 스킬이 실제로 쓰는 4종만 — 런타임 3(monolith·
+                  diagnostician·finalizer) + 유지보수 1(taxonomist).
   --force         대상에 일반 파일/디렉토리가 있어도 .bak.<ts> 백업 후 덮어씀
   --dry-run       실제 변경 없이 수행할 작업만 출력
   -h, --help      이 도움말
@@ -47,6 +57,7 @@ while [ $# -gt 0 ]; do
     --codex-only) DO_CLAUDE=no; DO_GEMINI=no ;;
     --gemini-only) DO_CLAUDE=no; DO_CODEX=no; DO_GEMINI=yes ;;
     --no-gemini) DO_GEMINI=no ;;
+    --all-agents) ALL_AGENTS=1 ;;
     --force) FORCE=1 ;;
     --dry-run) DRYRUN=1 ;;
     -h|--help) print_help; exit 0 ;;
@@ -99,9 +110,28 @@ if [ "$DO_CLAUDE" != no ] && { [ "$DO_CLAUDE" = yes ] || has_claude_target; }; t
   for s in humanize-korean humanize humanize-redo; do
     install_one "$REPO/.claude/skills/$s" "$CLAUDE_HOME/skills/$s"
   done
-  for a in "$REPO/agents"/*.md; do
-    install_one "$a" "$CLAUDE_HOME/agents/$(basename "$a")"
-  done
+  agents=()
+  if [ "$ALL_AGENTS" = 1 ]; then
+    for a in "$REPO/agents"/*.md; do
+      if [ -e "$a" ]; then agents[${#agents[@]}]="$a"; fi
+    done
+  else
+    for n in $INSTALLED_AGENTS; do
+      if [ -f "$REPO/agents/$n.md" ]; then
+        agents[${#agents[@]}]="$REPO/agents/$n.md"
+      else
+        echo "warn: agents/$n.md 를 찾지 못해 건너뜀" >&2
+      fi
+    done
+  fi
+  if [ "${#agents[@]}" -gt 0 ]; then
+    for a in "${agents[@]}"; do
+      install_one "$a" "$CLAUDE_HOME/agents/$(basename "$a")"
+    done
+  fi
+  if [ "$ALL_AGENTS" != 1 ]; then
+    echo "note: 릴리스 회차용 개발 에이전트는 설치하지 않음 (전체 설치는 --all-agents)"
+  fi
 else
   echo "== Claude Code: 건너뜀 (claude 또는 $CLAUDE_HOME 미감지) =="
 fi

--- a/tests/test_install_flags.sh
+++ b/tests/test_install_flags.sh
@@ -65,4 +65,24 @@ assert_contains "$claude_desktop_output" "+ ln -s $ROOT/.claude/skills/humanize-
 assert_not_contains "$claude_desktop_output" "Claude Code: "
 rm -rf "$TMP_HOME/.claude"
 
+# 에이전트 선별 설치 — 기본은 스킬이 실제로 쓰는 4종만.
+# agents/ 의 나머지 5종은 릴리스 회차용 개발 도구라 전역 풀에 상주시키지 않는다.
+RUNTIME_AGENTS="humanize-monolith humanize-diagnostician humanize-finalizer korean-ai-tell-taxonomist"
+DEV_ONLY_AGENTS="translationese-research-distiller korean-translation-scholar taxonomy-gap-analyzer post-editese-metric-engineer quick-rules-integrator"
+
+mkdir -p "$TMP_HOME/.claude"
+default_agents_output="$(run_installer --claude-only)"
+for a in $RUNTIME_AGENTS; do
+  assert_contains "$default_agents_output" "+ ln -s $ROOT/agents/$a.md $TMP_HOME/.claude/agents/$a.md"
+done
+for a in $DEV_ONLY_AGENTS; do
+  assert_not_contains "$default_agents_output" "$ROOT/agents/$a.md"
+done
+
+all_agents_output="$(run_installer --claude-only --all-agents)"
+for a in "$ROOT"/agents/*.md; do
+  assert_contains "$all_agents_output" "+ ln -s $a $TMP_HOME/.claude/agents/$(basename "$a")"
+done
+rm -rf "$TMP_HOME/.claude"
+
 echo "install flag tests passed"


### PR DESCRIPTION
## 요약

`install.sh`가 `agents/*.md` **9개를 전부** `~/.claude/agents/`에 심링크합니다.

```bash
for a in "$REPO/agents"/*.md; do
  install_one "$a" "$CLAUDE_HOME/agents/$(basename "$a")"
```

그중 5개는 README가 직접 **"릴리스 회차 전용 개발 도구 … 윤문 실행과 무관"**이라 명시한 정의입니다 — `translationese-research-distiller` · `korean-translation-scholar` · `taxonomy-gap-analyzer` · `post-editese-metric-engineer` · `quick-rules-integrator`. SKILL.md도 "개발용 1회성 5종"으로 분류합니다.

서브에이전트는 description 매칭으로 자동 라우팅되므로, **전역 풀에 상주하는 정의는 이 스킬과 무관한 세션에서도 후보가 됩니다.** 한글 윤문 도구를 설치한 대가로 사용자의 전역 에이전트 네임스페이스에 번역학 연구 정제기가 들어앉는 구조입니다.

## 변경

1. 기본 설치를 **런타임 3종 + 유지보수 1종**으로 한정 — SKILL.md "에이전트 호출 규칙" 절이 선언하는 그 4종과 동일

   ```
   humanize-monolith · humanize-diagnostician · humanize-finalizer · korean-ai-tell-taxonomist
   ```

2. **`--all-agents`** 플래그로 기존 동작(9종 전부) 유지 — 레포 기여자용. 하위호환 이탈 경로를 남겨둡니다
3. 목록의 정의가 실물로 없으면 `warn` 후 건너뜀 (설치 자체는 계속)
4. 기본 설치 시 한 줄 고지: `note: 릴리스 회차용 개발 에이전트는 설치하지 않음 (전체 설치는 --all-agents)`
5. `INSTALL.md`의 "에이전트 9개" 서술을 4개 + 제외 사유로 정정

## 범위 밖 (그대로 둠)

- **마켓플레이스/플러그인 설치**는 `agents/` 번들을 그대로 제공합니다. 플러그인 패키징 규약이라 손대지 않았고, README·INSTALL의 "서브에이전트 9개" 서술도 그 경로에 대해서는 여전히 맞습니다.
- **`uninstall.sh`**는 `agents/*.md` 전수를 돌며 우리 심링크만 지우므로, 구버전이 깔아둔 5종도 그대로 정리됩니다. 수정 불필요.

## CI — 이 테스트는 지금까지 한 번도 돈 적이 없습니다

`tests/test_install_flags.sh`는 셸 스크립트라 `pytest tests/`가 수집하지 않습니다. 워크플로에도 없어서 **CI에서 실행된 적이 없습니다.** 이번에 단언을 추가하면서 스텝으로 등록했습니다:

```yaml
- run: bash tests/test_install_flags.sh
```

## 검증

```
$ bash -n install.sh && bash -n tests/test_install_flags.sh
install.sh 문법 OK / test 문법 OK

$ bash tests/test_install_flags.sh
install flag tests passed                                    # exit 0

$ ./install.sh --claude-only --dry-run | grep -c 'ln -s.*agents/'
4
$ ./install.sh --claude-only --all-agents --dry-run | grep -c 'ln -s.*agents/'
9

$ python3 -m pytest tests/ -q --ignore=tests/test_humanize_live.py
185 passed, 1 skipped, 12 subtests passed in 0.37s
```

수정 전 상태에서 신규 단언을 돌리면 정확히 실패합니다:

```
expected output not to contain: …/agents/translationese-research-distiller.md
```

`bash 3.2`(macOS 기본)에서 `set -euo pipefail` 하에 빈 배열 전개가 터지지 않도록 `${#agents[@]}` 카운트로 가드했습니다.

## 판단이 필요한 부분

기본값을 4종으로 좁히는 건 **동작 변경**입니다. 개발용 5종을 전역에 두는 게 의도된 선택이었다면 이 PR은 닫으셔도 됩니다 — 그 경우 README·SKILL.md가 "윤문 실행과 무관"이라 적은 부분과의 정합만 따로 맞추면 되겠습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
