### PR TITLE
fix(shim): --run-dir·--diagnosis 상대경로를 cwd 기준으로 해석 (#71)

### DIFF
--- a/.claude/skills/humanize-korean/SKILL.md
+++ b/.claude/skills/humanize-korean/SKILL.md
@@ -52,7 +52,7 @@ humanize-korean v2.3 — 경로: {light|standard|heavy} ({route_hint|사용자 �
    python3 scripts/prepare_monolith_input.py --run-dir _workspace/{run_id} --genre {genre}
    ```
    - `--genre` 값은 영문 키: `essay | column | report | blog | abstract` (생략 시 `essay`). 장르 힌트 매핑: 칼럼→`column`, 리포트→`report`, 블로그→`blog`, 공적/기타→`essay`.
-   - `--run-dir`는 프로젝트 루트 기준 상대 경로 허용 (스크립트가 절대화). 그 외 인자: `--text`(run-dir 없이 즉석 실행 시 새 run 디렉토리 자동 생성), `--baseline`(baseline JSON 경로 override, 평소 불필요), `--diagnosis`(진단 텍스트 파일을 점수 블록 앞에 prepend — standard·heavy의 진단 결합용).
+   - `--run-dir`·`--diagnosis`의 상대 경로는 **cwd 기준**으로 해석된다(위 run_id 규칙과 동일 기준). 그 외 인자: `--text`(run-dir 없이 즉석 실행 시 새 run 디렉토리 자동 생성), `--baseline`(baseline JSON 경로 override, 평소 불필요), `--diagnosis`(진단 텍스트 파일을 점수 블록 앞에 prepend — standard·heavy의 진단 결합용).
    - 산출: `00_metrics.json`(정량 점수 + **`route_hint`**) + `01_input_with_metrics.txt`(점수 블록을 원문 앞에 붙인 결합 파일).
    - **graceful degrade 내장**: metrics 계산이 실패하면 shim이 점수 블록 없이 원문만 감싼 결합 파일을 쓰고 `00_metrics.error`를 남긴다. 이 경우 route_hint 없음 → standard 경로.
 5. `00_metrics.json`의 `route_hint`를 읽어 Phase 0 규칙대로 경로를 확정하고 상태 줄을 출력한다.

--- a/scripts/prepare_monolith_input.py
+++ b/scripts/prepare_monolith_input.py
@@ -84,15 +84,33 @@ def _next_run_dir(workspace: Path) -> Path:
 
 
 def _resolve_run_dir(run_dir_arg: str | None, text_arg: str | None) -> Path:
+    """상대 경로는 **cwd** 기준으로 푼다.
+
+    이전에는 PROJECT_ROOT(설치 저장소 루트) 기준이었다. SKILL.md 는 "모든 경로는
+    cwd 기준"이라고 지시하는데 스크립트는 저장소 루트에서 찾으니, 심링크로 설치해
+    사용자 작업 디렉터리에서 스킬을 부르는 정상 흐름이 첫 실행부터 실패했다.
+    (저장소 루트에서 돌릴 때는 cwd == PROJECT_ROOT 라 동작이 같다.)
+
+    빈 디렉터리도 남기지 않는다 — 예전에는 존재 확인 전에 mkdir 을 해서, 실패할
+    때마다 설치 위치에 빈 `_workspace/{run_id}/` 가 쌓였다. 새로 만드는 경우
+    (--text)에만 생성한다.
+    """
     if run_dir_arg:
         rd = Path(run_dir_arg)
         if not rd.is_absolute():
-            rd = PROJECT_ROOT / rd
-        rd.mkdir(parents=True, exist_ok=True)
+            rd = Path.cwd() / rd
+        if text_arg is not None:
+            rd.mkdir(parents=True, exist_ok=True)  # 입력을 쓸 것이므로 생성
+        elif not rd.is_dir():
+            raise SystemExit(
+                f"run-dir not found: {rd}\n"
+                "  (상대 경로는 현재 디렉터리 기준으로 해석됩니다. "
+                "--text 를 주면 새로 만듭니다.)"
+            )
         return rd
     if text_arg is None:
         raise SystemExit("Either --run-dir or --text is required")
-    workspace = PROJECT_ROOT / "_workspace"
+    workspace = Path.cwd() / "_workspace"
     rd = _next_run_dir(workspace)
     rd.mkdir(parents=True, exist_ok=True)
     return rd
@@ -820,7 +838,7 @@ def main(argv: list[str] | None = None) -> int:
     if args.diagnosis:
         diag_path = Path(args.diagnosis)
         if not diag_path.is_absolute():
-            diag_path = PROJECT_ROOT / diag_path
+            diag_path = Path.cwd() / diag_path  # --run-dir 과 같은 기준(cwd)
         if not diag_path.exists():
             raise SystemExit(f"--diagnosis file not found: {diag_path}")
         diagnosis = diag_path.read_text(encoding="utf-8")

--- a/tests/test_run_dir_resolution.py
+++ b/tests/test_run_dir_resolution.py
@@ -1,0 +1,113 @@
+"""--run-dir·--diagnosis 상대경로가 **cwd 기준**으로 풀리는지 검증 (#71).
+
+배경: 예전에는 PROJECT_ROOT(설치 저장소 루트) 기준이었다. SKILL.md 는 "모든 경로는
+cwd 기준"이라 지시하는데 스크립트는 저장소 루트에서 찾으니, 심링크로 설치해 사용자
+작업 디렉터리에서 스킬을 부르는 정상 흐름이 첫 실행부터 실패했다. 저장소 루트에서
+돌릴 때는 cwd == PROJECT_ROOT 라 아무도 눈치채지 못했다 — 그래서 회귀 테스트는
+반드시 **저장소 밖 cwd** 에서 돌려야 의미가 있다.
+
+실행: python3 -m pytest tests/test_run_dir_resolution.py -q
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+_HERE = Path(__file__).resolve().parent
+_ROOT = _HERE.parent
+_SHIM = _ROOT / "scripts" / "prepare_monolith_input.py"
+
+SAMPLE = "이것은 시험용 문장입니다. 첫째, 확인이 필요합니다. 둘째, 검증이 필요합니다."
+
+
+def _run(args: list[str], cwd: Path) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [sys.executable, str(_SHIM), *args],
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+
+
+class RunDirResolutionTests(unittest.TestCase):
+    def test_relative_run_dir_resolves_against_cwd(self) -> None:
+        """저장소 밖 cwd 에서 상대 --run-dir 이 그 cwd 기준으로 풀려야 한다."""
+        with tempfile.TemporaryDirectory() as td:
+            work = Path(td)
+            run = work / "_workspace" / "2026-08-17-001"
+            run.mkdir(parents=True)
+            (run / "01_input.txt").write_text(SAMPLE, encoding="utf-8")
+
+            proc = _run(["--run-dir", "_workspace/2026-08-17-001"], cwd=work)
+            self.assertEqual(proc.returncode, 0, f"stderr={proc.stderr}")
+            # 결합 파일이 **사용자 작업 디렉터리** 아래 생겨야 한다
+            self.assertTrue((run / "01_input_with_metrics.txt").is_file())
+            self.assertIn(str(run), proc.stdout)
+
+    def test_missing_run_dir_does_not_create_empty_dir(self) -> None:
+        """존재하지 않는 run-dir 은 만들지 않고 실패해야 한다.
+
+        예전에는 존재 확인 전에 mkdir 을 해서, 실패할 때마다 설치 위치에 빈
+        `_workspace/{run_id}/` 가 쌓였다.
+        """
+        with tempfile.TemporaryDirectory() as td:
+            work = Path(td)
+            proc = _run(["--run-dir", "_workspace/없는폴더"], cwd=work)
+            self.assertNotEqual(proc.returncode, 0)
+            self.assertFalse((work / "_workspace" / "없는폴더").exists())
+            # 설치 저장소에도 남기지 않는다
+            self.assertFalse((_ROOT / "_workspace" / "없는폴더").exists())
+
+    def test_text_arg_creates_run_dir_under_cwd(self) -> None:
+        """--text 는 cwd 아래에 새 run 디렉터리를 만든다."""
+        with tempfile.TemporaryDirectory() as td:
+            work = Path(td)
+            proc = _run(["--text", SAMPLE], cwd=work)
+            self.assertEqual(proc.returncode, 0, f"stderr={proc.stderr}")
+            made = list((work / "_workspace").glob("*/01_input_with_metrics.txt"))
+            self.assertEqual(len(made), 1, "cwd 아래에 run 디렉터리가 하나 생겨야 함")
+
+    def test_relative_diagnosis_resolves_against_cwd(self) -> None:
+        """--diagnosis 도 --run-dir 과 같은 기준(cwd)이어야 한다."""
+        with tempfile.TemporaryDirectory() as td:
+            work = Path(td)
+            run = work / "_workspace" / "2026-08-17-002"
+            run.mkdir(parents=True)
+            (run / "01_input.txt").write_text(SAMPLE, encoding="utf-8")
+            diag = run / "02_diagnosis.md"
+            diag.write_text("## 진단\n- C-8 대구 과잉\n", encoding="utf-8")
+
+            proc = _run(
+                [
+                    "--run-dir",
+                    "_workspace/2026-08-17-002",
+                    "--diagnosis",
+                    "_workspace/2026-08-17-002/02_diagnosis.md",
+                ],
+                cwd=work,
+            )
+            self.assertEqual(proc.returncode, 0, f"stderr={proc.stderr}")
+            combined = (run / "01_input_with_metrics.txt").read_text(encoding="utf-8")
+            self.assertIn("C-8 대구 과잉", combined, "진단이 결합 파일에 실려야 함")
+
+    def test_absolute_run_dir_still_works(self) -> None:
+        """절대 경로는 그대로 쓴다 (기존 동작 보존)."""
+        with tempfile.TemporaryDirectory() as td:
+            work = Path(td)
+            run = work / "abs_run"
+            run.mkdir()
+            (run / "01_input.txt").write_text(SAMPLE, encoding="utf-8")
+            # cwd 를 저장소 루트로 둬도 절대경로가 이겨야 한다
+            proc = _run(["--run-dir", str(run)], cwd=_ROOT)
+            self.assertEqual(proc.returncode, 0, f"stderr={proc.stderr}")
+            self.assertTrue((run / "01_input_with_metrics.txt").is_file())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
@bukbuk82-alt 님이 #71 에서 보고해주신 버그입니다. 재현·원인 분석·SKILL.md 내부 모순까지 정확히 짚어주셔서 그대로 확인됐습니다.

## 문제

`_resolve_run_dir()` 이 상대경로를 `PROJECT_ROOT`(설치 저장소 루트) 기준으로 절대화하는데, SKILL.md 는 "모든 경로는 cwd 기준"이라고 지시한다. 심링크 설치 후 사용자 작업 디렉터리에서 스킬을 부르는 **정상 사용 흐름이 첫 실행부터 항상 실패**한다. 저장소 루트에서 돌릴 때는 `cwd == PROJECT_ROOT` 라 그동안 드러나지 않았다.

## 변경

- `--run-dir` 상대경로 → **cwd 기준**. 절대경로는 그대로.
- `--diagnosis` 도 같은 기준으로 통일 — 두 인자 기준이 다르면 heavy 경로에서 진단 결합이 조용히 실패한다.
- `--text` 로 새 run 을 만들 때의 워크스페이스도 cwd 기준.
- **빈 디렉터리 누적 제거** — 존재 확인 전에 `mkdir` 하던 것을 고쳤다. 이제 없는 run-dir 은 안내와 함께 실패한다.
- SKILL.md L55 모순 문구 정정.

## 테스트

`tests/test_run_dir_resolution.py` 5건 신규. **저장소 밖 임시 cwd** 에서 subprocess 로 실행한다 — 저장소 루트에서 돌리면 옛 버그도 통과해버리므로, 이 회귀는 cwd 를 옮겨야만 잡힌다.

pytest 218 passed.

Closes #71