### PR TITLE
fix(gates): checks.py 를 프로덕션 위치로 이동 — tests/ 런타임 의존 제거 (#59)

### DIFF
--- a/scripts/checks.py
+++ b/scripts/checks.py
@@ -8,7 +8,7 @@ documented failure modes fail.
 
 stdlib only. Usage as a library:
 
-    from checks import run_checks
+    from checks import run_checks  # scripts/ 에 위치
     failures = run_checks(original_text, rewritten_text)
     # empty list == PASS
 

--- a/scripts/verify_gates.py
+++ b/scripts/verify_gates.py
@@ -13,7 +13,7 @@ ending_comma -86%, C-8 대구 -75%가 숨어 있었다. 이 스크립트는 문�
     P1 목표달성 — before z > +2.0인 어휘 S1 지표가 after에서 z <= +1.0으로
                   내려왔는가. 미달(> +2.0)·과교정(< -1.5)은 WARN.
     P2 전멸    — C-8 대구: before >= 5 AND after == 0 이면 FAIL.
-    P3 golden  — tests/golden/checks.run_checks() 실패 목록 (수치 주입 포함).
+    P3 golden  — scripts/checks.run_checks() 실패 목록 (수치 주입 포함).
     P4 터치율  — 원문 문장 중 after에 그대로 없는 비율 + 수치 소실 관찰.
                  게이트 아님, 보고만 (수치 소실은 문장 병합·표기 통합의
                  정상 부산물일 수 있어 exit code에 기여하지 않는다).
@@ -43,8 +43,10 @@ import sys
 _HERE = os.path.dirname(os.path.abspath(__file__))
 _ROOT = os.path.abspath(os.path.join(_HERE, ".."))
 _REFS = os.path.join(_ROOT, ".claude", "skills", "humanize-korean", "references")
-_GOLDEN = os.path.join(_ROOT, "tests", "golden")
-for _p in (_REFS, _GOLDEN):
+# checks 는 프로덕션 검사 구현이라 scripts/ 에 둔다(이 파일과 같은 디렉터리).
+# 예전에는 tests/golden/ 에 있어 프로덕션 게이트가 테스트 트리를 런타임 import 했고,
+# tests/ 를 뺀 선별 배포에서는 P3 golden 축이 통째로 죽었다. (#59)
+for _p in (_REFS, _HERE):
     if _p not in sys.path:
         sys.path.insert(0, _p)
 

--- a/tests/golden/README.md
+++ b/tests/golden/README.md
@@ -27,7 +27,7 @@ pytest tests/test_golden.py
 python3 -m unittest tests.test_golden
 
 # 채점기 단독 — 실제 윤문 결과를 게이트에 통과시킬 때
-python3 tests/golden/checks.py fixtures/01_register_downgrade/input.txt <윤문결과.txt>
+python3 scripts/checks.py fixtures/01_register_downgrade/input.txt <윤문결과.txt>
 ```
 
 CI에서는 LLM을 부를 수 없으므로 자동 테스트는 **채점기 자체**를 양방향으로 검증합니다

--- a/tests/test_golden.py
+++ b/tests/test_golden.py
@@ -10,7 +10,7 @@ suite validates the deterministic scorer itself, both directions:
                 failure codes declared in expected_failures.json
 
 To gate a real pipeline run, feed the actual rewrite of input.txt through
-tests/golden/checks.py (see tests/golden/README.md).
+scripts/checks.py (see tests/golden/README.md).
 """
 
 from __future__ import annotations
@@ -24,6 +24,7 @@ HERE = os.path.dirname(os.path.abspath(__file__))
 GOLDEN_DIR = os.path.join(HERE, "golden")
 FIXTURES_DIR = os.path.join(GOLDEN_DIR, "fixtures")
 sys.path.insert(0, GOLDEN_DIR)
+sys.path.insert(0, os.path.join(HERE, "..", "scripts"))  # checks 는 프로덕션 위치(#59)
 
 import checks  # noqa: E402
 

--- a/tests/test_runtime_boundary.py
+++ b/tests/test_runtime_boundary.py
@@ -1,0 +1,97 @@
+"""프로덕션 런타임이 tests/ 트리에 의존하지 않는지 검증 (#59).
+
+배경: `scripts/verify_gates.py`(프로덕션 게이트)가 `tests/golden/checks.py` 를
+런타임에 import 하고 있었다. 저장소 전체를 배포하는 Claude Code 설치에서는
+동작하지만, 런타임 파일만 선별 배포하는 구조(포트·zip·심링크 부분 배포)에서는
+**P3 golden 축이 통째로 죽는다**. 게이트가 조용히 한 축을 잃는 것이 가장 나쁘다.
+
+checks.py 는 이름만 tests 아래 있었을 뿐 내용은 전부 프로덕션 검사 로직
+(register·heading·footnote·number·quote)이라 `scripts/` 로 옮겼다.
+
+이 테스트는 그 경계가 다시 무너지면 실패한다.
+"""
+
+from __future__ import annotations
+
+import ast
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+_HERE = Path(__file__).resolve().parent
+_ROOT = _HERE.parent
+_SCRIPTS = _ROOT / "scripts"
+
+# 프로덕션 런타임에 해당하는 스크립트(스킬이 Bash 로 직접 부르는 것들)
+_RUNTIME_SCRIPTS = [
+    "verify_gates.py",
+    "verify_change_rate.py",
+    "prepare_monolith_input.py",
+    "reassemble_chunks.py",
+    "sanitize_text.py",
+    "checks.py",
+]
+
+
+class RuntimeBoundaryTests(unittest.TestCase):
+    def test_runtime_scripts_do_not_reference_tests_tree(self) -> None:
+        """런타임 스크립트 소스에 tests/ 경로 조립이 없어야 한다."""
+        offenders: list[str] = []
+        for name in _RUNTIME_SCRIPTS:
+            p = _SCRIPTS / name
+            if not p.is_file():
+                continue
+            src = p.read_text(encoding="utf-8")
+            for lineno, line in enumerate(src.splitlines(), 1):
+                stripped = line.strip()
+                if stripped.startswith("#"):
+                    continue  # 주석의 이력 서술은 허용
+                if '"tests"' in line or "'tests'" in line or "tests/golden" in line:
+                    offenders.append(f"{name}:{lineno}: {stripped[:90]}")
+        self.assertEqual(offenders, [], "런타임이 tests/ 를 참조함:\n" + "\n".join(offenders))
+
+    def test_checks_lives_in_scripts(self) -> None:
+        """checks.py 는 프로덕션 위치에 있어야 한다."""
+        self.assertTrue((_SCRIPTS / "checks.py").is_file(), "scripts/checks.py 가 없음")
+        self.assertFalse(
+            (_ROOT / "tests" / "golden" / "checks.py").is_file(),
+            "tests/golden/checks.py 가 되살아남 — 프로덕션 구현은 scripts/ 에 둔다",
+        )
+
+    def test_verify_gates_runs_without_tests_dir(self) -> None:
+        """tests/ 를 뺀 선별 배포에서도 게이트 전 축이 동작해야 한다 (#59 핵심)."""
+        with tempfile.TemporaryDirectory() as td:
+            d = Path(td)
+            (d / "scripts").mkdir()
+            for f in _SCRIPTS.glob("*.py"):
+                (d / "scripts" / f.name).write_bytes(f.read_bytes())
+            refs_src = _ROOT / ".claude" / "skills" / "humanize-korean" / "references"
+            refs_dst = d / ".claude" / "skills" / "humanize-korean" / "references"
+            refs_dst.mkdir(parents=True)
+            for f in refs_src.iterdir():
+                if f.is_file():
+                    (refs_dst / f.name).write_bytes(f.read_bytes())
+
+            self.assertFalse((d / "tests").exists(), "tests/ 가 없어야 하는 조건")
+
+            (d / "before.txt").write_text(
+                "원문은 이러하다. 수치는 1,200명이다.", encoding="utf-8"
+            )
+            (d / "after.txt").write_text(
+                "원문은 이렇다. 수치는 1,200명이다.", encoding="utf-8"
+            )
+            proc = subprocess.run(
+                [sys.executable, "scripts/verify_gates.py", "--before", "before.txt",
+                 "--after", "after.txt"],
+                cwd=d, capture_output=True, text=True, timeout=120,
+            )
+            self.assertIn("[P3 golden]", proc.stdout, f"golden 축 누락\n{proc.stdout}\n{proc.stderr}")
+            self.assertNotIn("ModuleNotFoundError", proc.stderr)
+            self.assertIn(proc.returncode, (0, 1), f"예상치 못한 종료: {proc.returncode}\n{proc.stderr}")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
@andrea9292 님이 #59 에서 제기하신 경계 문제입니다. Hermes 포트를 만드시면서 발견하신 것인데, 확인 결과 **실재하는 결함**이었습니다.

## 문제

`scripts/verify_gates.py`(프로덕션 게이트)가 `tests/golden/checks.py` 를 런타임에 import 한다. 저장소 전체를 배포하는 Claude Code 설치에서는 동작하지만, 런타임 파일만 선별 배포하는 구조에서는 **P3 golden 축이 통째로 죽는다.** 게이트가 조용히 한 축을 잃는 것이 가장 나쁜 실패다 — 실패했다는 사실조차 안 보인다.

## 판단

`checks.py` 는 이름만 `tests/` 아래 있었을 뿐 내용은 전부 프로덕션 검사 로직입니다(register·heading·footnote·number·quote). **위치가 잘못됐던 것**이라 `scripts/` 로 옮기고, `verify_gates.py` 는 자기 디렉터리에서 import 하도록 했습니다. 지적하신 "물리적 경계를 명확히 할 필요"에 그대로 해당합니다.

## 실측 검증

`scripts/` + `references/` 만 복사하고 `tests/` 가 없는 트리에서:

```
[P0 문자율] 6.7% [전문] — OK
[P1 목표달성] N/A — 구조 진단
[P2 전멸] C-8 대구 0 → 0 — 스킵
[P3 golden] PASS          ← 예전에는 ModuleNotFoundError
[P4 터치율] 50.0% — 보고 전용
gate: OK — 수렴
```

## 회귀 방지

`tests/test_runtime_boundary.py` 3건 신규.

1. 런타임 스크립트 소스에 `tests/` 경로 조립 금지 (주석의 이력 서술은 허용)
2. `checks.py` 가 `scripts/` 에 있고 `tests/golden/` 에 되살아나지 않았는지
3. **`tests/` 를 뺀 트리에서 게이트 전 축이 실제로 도는지** — subprocess 로 진짜 실행

경계는 문서가 아니라 테스트가 지켜야 다시 안 무너집니다.

pytest 221 passed.

Closes #59