### PR TITLE
fix(install): 구버전·은퇴 에이전트 전역 링크 자동 정리 (#73)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -85,6 +85,45 @@ prepare_target() {
   return 0
 }
 
+# 구버전 설치가 남긴 전역 에이전트 링크를 정리한다 (#73).
+#
+# 두 부류를 지운다.
+#   1) 이 저장소가 심었지만 지금 설치 범위 밖인 것 (개발용 5종 — #70 이전 설치본)
+#   2) dangling — 대상이 사라진 은퇴 에이전트 링크
+#      (ai-tell-detector·korean-style-rewriter·content-fidelity-auditor·
+#       naturalness-reviewer·humanize-web-architect 등 v2.1 은퇴분)
+#
+# **소유권 판별은 심링크 대상으로만 한다.** 이 저장소의 agents/ 를 가리키는
+# 심링크만 대상이며, 사용자가 직접 만든 파일이나 다른 도구가 심은 링크는
+# 절대 건드리지 않는다. 복사(copy) 설치는 소유 판별이 불가능하므로 건너뛴다.
+prune_stale_agents() {
+  local dir="$CLAUDE_HOME/agents"
+  [ -d "$dir" ] || return 0
+  local keep=" $INSTALLED_AGENTS "
+  local f base target pruned=0
+  for f in "$dir"/*.md; do
+    # glob 미매칭 시 리터럴이 들어오므로 심링크인 것만 통과
+    [ -L "$f" ] || continue
+    target="$(readlink "$f")"
+    case "$target" in
+      "$REPO/agents/"*) ;;   # 이 저장소가 심은 것 → 대상
+      *) continue ;;         # 남의 것 → 손대지 않음
+    esac
+    base="$(basename "$f" .md)"
+    if [ -e "$target" ]; then
+      # 대상이 살아있음 → 설치 범위 밖일 때만 정리
+      [ "$ALL_AGENTS" = 1 ] && continue
+      case "$keep" in *" $base "*) continue ;; esac
+    fi
+    # 여기 도달 = 범위 밖이거나 dangling
+    run rm -f "$f"
+    echo "pruned: $f"
+    pruned=$((pruned + 1))
+  done
+  [ "$pruned" -gt 0 ] && echo "note: 구버전·은퇴 에이전트 링크 ${pruned}건 정리됨"
+  return 0
+}
+
 install_one() {
   local src="$1" dest="$2"
   run mkdir -p "$(dirname "$dest")"
@@ -128,6 +167,11 @@ if [ "$DO_CLAUDE" != no ] && { [ "$DO_CLAUDE" = yes ] || has_claude_target; }; t
     for a in "${agents[@]}"; do
       install_one "$a" "$CLAUDE_HOME/agents/$(basename "$a")"
     done
+  fi
+  # 설치 후 정리 — 구버전 설치본이 남긴 범위 밖·은퇴 링크 제거 (#73).
+  # 심링크 모드에서만 동작한다(복사 설치는 소유 판별 불가).
+  if [ "$MODE" = symlink ]; then
+    prune_stale_agents
   fi
   if [ "$ALL_AGENTS" != 1 ]; then
     echo "note: 릴리스 회차용 개발 에이전트는 설치하지 않음 (전체 설치는 --all-agents)"

--- a/tests/test_install_flags.sh
+++ b/tests/test_install_flags.sh
@@ -85,4 +85,29 @@ for a in "$ROOT"/agents/*.md; do
 done
 rm -rf "$TMP_HOME/.claude"
 
+# ── 구버전 링크 정리 (#73) ─────────────────────────────────────────────
+# 이 저장소가 심은 링크만 지운다. 사용자 소유 파일·남의 링크는 절대 건드리지 않는다.
+mkdir -p "$TMP_HOME/.claude/agents"
+ln -s "$ROOT/agents/quick-rules-integrator.md" "$TMP_HOME/.claude/agents/quick-rules-integrator.md"   # 범위 밖(개발용)
+ln -s "$ROOT/agents/naturalness-reviewer.md"  "$TMP_HOME/.claude/agents/naturalness-reviewer.md"      # 은퇴 = dangling
+ln -s "/tmp/some-other-tool.md"               "$TMP_HOME/.claude/agents/other-tool.md"                # 남의 링크
+printf 'user owned\n' > "$TMP_HOME/.claude/agents/my-own-agent.md"                                    # 사용자 파일
+
+prune_output="$(run_installer --claude-only)"
+assert_contains "$prune_output" "pruned: $TMP_HOME/.claude/agents/quick-rules-integrator.md"
+assert_contains "$prune_output" "pruned: $TMP_HOME/.claude/agents/naturalness-reviewer.md"
+# 남의 것은 손대지 않는다 — 이 두 단언이 이 기능의 안전장치다
+assert_not_contains "$prune_output" "pruned: $TMP_HOME/.claude/agents/other-tool.md"
+assert_not_contains "$prune_output" "pruned: $TMP_HOME/.claude/agents/my-own-agent.md"
+
+# --all-agents 면 개발용도 정식 설치 대상이므로 지우지 않는다(dangling 만 정리)
+rm -rf "$TMP_HOME/.claude"
+mkdir -p "$TMP_HOME/.claude/agents"
+ln -s "$ROOT/agents/quick-rules-integrator.md" "$TMP_HOME/.claude/agents/quick-rules-integrator.md"
+ln -s "$ROOT/agents/naturalness-reviewer.md"  "$TMP_HOME/.claude/agents/naturalness-reviewer.md"
+all_prune_output="$(run_installer --claude-only --all-agents)"
+assert_not_contains "$all_prune_output" "pruned: $TMP_HOME/.claude/agents/quick-rules-integrator.md"
+assert_contains "$all_prune_output" "pruned: $TMP_HOME/.claude/agents/naturalness-reviewer.md"
+rm -rf "$TMP_HOME/.claude"
+
 echo "install flag tests passed"


### PR DESCRIPTION
#70 의 후속입니다. 원 아이디어는 #57 (@yswyang0228) 에서 왔고, 그 PR 은 다른 사유로 닫으면서 이 부분만 승계하기로 했던 것을 구현했습니다.

## 문제

전역 설치 범위를 런타임 4종으로 좁혔지만, **이미 구버전으로 설치한 사용자**가 재실행해도 `~/.claude/agents/` 에 남은 개발용 5종 링크는 그대로 남았습니다. v2.1 에서 은퇴한 5종의 dangling 링크도 마찬가지입니다. 전역 에이전트 description 은 모든 세션에 로드되므로, 윤문과 무관한 정의가 계속 상주하며 다른 작업에서 잘못 호출될 수 있습니다.

## 안전장치가 이 변경의 핵심

**소유권은 심링크 대상으로만 판별합니다.** 이 저장소의 `agents/` 를 가리키는 심링크만 대상입니다.

| 대상 | 처리 |
|---|---|
| 이 저장소가 심었고 지금 범위 밖 | 제거 |
| 이 저장소를 가리키는 dangling | 제거 |
| 사용자가 직접 만든 파일 | **건드리지 않음** |
| 다른 도구가 심은 링크 | **건드리지 않음** |
| 복사(copy) 설치 | **정리 건너뜀** (소유 판별 불가) |

`--all-agents` 면 개발용도 정식 설치 대상이므로 dangling 만 정리합니다.

## 검증

격리 환경에 4종을 배치하고 실행:

```
pruned: quick-rules-integrator.md   (범위 밖)
pruned: naturalness-reviewer.md     (dangling)
other-tool.md      → 남음   (남의 심링크)
my-own-agent.md    → 남음   (사용자 파일)
```

뒤의 두 단언이 안전장치입니다. `tests/test_install_flags.sh` 에 `--all-agents` 케이스 포함해 회귀로 고정했습니다(#70 이 이 셸 테스트를 CI 에 등록해 둔 덕에 자동으로 돕니다).

pytest 223 passed + install flag tests passed.

Closes #73