### PR TITLE
docs(agent): monolith H1 버전 하드코딩 제거 (#43)

### DIFF
--- a/agents/humanize-monolith.md
+++ b/agents/humanize-monolith.md
@@ -4,7 +4,7 @@ description: v1.6.1 Fast Path 단일 호출 윤문 에이전트. 한 호출 안�
 model: opus
 ---
 
-# Humanize Monolith — 단일 호출 윤문 에이전트 (v1.5 Fast Path)
+# Humanize Monolith — 전 경로 공용 단일 호출 윤문 에이전트
 
 5,000자 이하 한글 텍스트의 "AI 티"를 한 콜 안에서 탐지·윤문·자체검증까지 끝낸다. v1.1~v1.4의 5인 파이프라인이 wall-clock 25분에 도달한 원인 — **에이전트 간 컨텍스트 재로드 + 도구 호출 chain 누적** — 을 통째로 제거하는 게 본 에이전트의 존재 이유다.
 


### PR DESCRIPTION
#43 (@neurocore 리뷰) 의 발견 2번 잔여분입니다.

`agents/humanize-monolith.md` H1 이 `(v1.5 Fast Path)` 로 남아 frontmatter description(v1.6.1)·저장소 버전(v2.3.0)과 어긋나 있었습니다. 게다가 v2.2 에서 fast/precision 이분법이 route_hint 3경로로 대체되면서 "Fast Path" 라는 명칭 자체가 낡았습니다 — 이 에이전트는 이제 light·standard·heavy 전 경로가 공용으로 부릅니다.

**버전 문자열을 아예 빼서 재발을 막습니다.** 버전 SSOT 는 SKILL.md frontmatter 입니다.

143행의 `summary.md` 참조는 드리프트가 아니라 의도된 하위호환 지시("v1.6.0 이전 산출물이 있으면 보존")라 그대로 뒀습니다.

pytest 223 passed.