### PR TITLE
fix(windows): cp949 콘솔 사망 + 스크립트 경로 절대화 (#84)

### DIFF
--- a/.claude/skills/humanize-korean/SKILL.md
+++ b/.claude/skills/humanize-korean/SKILL.md
@@ -43,6 +43,26 @@ humanize-korean v2.3 — 경로: {light|standard|heavy} ({route_hint|사용자 �
 - 당일 폴더가 없으면 NNN = 001. 있으면 마지막 NNN + 1.
 - 부분 재실행 신호("이 카테고리만 다시"·"2차 윤문")일 경우 기존 run_id 재사용 + heavy 경로로 자동 승급.
 
+## 스크립트 경로 규칙 (`${SKILL_ROOT}`)
+
+**스크립트는 절대경로로 부른다. cwd 기준 상대경로로 부르면 안 된다.**
+
+`scripts/*.py`는 설치 루트에 있고 cwd 는 사용자 작업 디렉터리다. 마켓플레이스 설치에서 둘은 **절대 일치하지 않는다.** 반면 `_workspace/` 같은 데이터 경로는 cwd 기준이다(run_id 규칙 참조). 두 기준이 한 명령줄에 섞이므로 스크립트 쪽만 절대경로로 고정한다.
+
+Phase 1 시작 전에 한 번 정한다.
+
+```bash
+SKILL_ROOT="$(cd -P "${CLAUDE_SKILL_DIR}" && cd ../../.. && pwd)"
+```
+
+`${CLAUDE_SKILL_DIR}`는 `<설치루트>/.claude/skills/humanize-korean` 이므로 상위 3단계가 설치 루트다.
+
+**`cd -P` 가 핵심이다.** 심링크 설치(`install.sh` 기본)에서는 스킬 디렉터리가 저장소를 가리키는 심링크라, 그냥 `cd` 하면 셸이 논리 경로를 유지해 엉뚱한 곳(홈 디렉터리)으로 올라간다. `-P` 로 물리 경로를 먼저 푼 뒤 올라가야 심링크·플러그인 양쪽에서 같은 답이 나온다. 이후 모든 스크립트 호출에 `${SKILL_ROOT}/scripts/...` 를 쓴다.
+
+**확인**: `ls "${SKILL_ROOT}/scripts/prepare_monolith_input.py"` 가 실패하면 경로 유도가 틀린 것이다. 이 경우 스크립트를 찾을 때까지 임의로 추측하지 말고, 정량 shim·게이트 없이 진행한다고 **사용자에게 알린 뒤** 계속한다. 조용히 건너뛰면 route_hint 와 철칙 #4 게이트가 사라진 것을 아무도 모른다.
+
+> `CLAUDE_PLUGIN_ROOT` 는 Bash 도구 안에서 비어 있는 경우가 확인됐다(#84). 이 변수에 의존하지 않는다.
+
 ## Phase 1: 입력 저장 + 정량 사전 점수 (input shim — 전 경로 공통)
 
 1. cwd 기준 `_workspace/{run_id}/` 생성
@@ -50,7 +70,7 @@ humanize-korean v2.3 — 경로: {light|standard|heavy} ({route_hint|사용자 �
 3. 첫 300자로 장르 자동 추정 (사용자 명시 시 우선)
 4. 사전 처리 shim을 Bash로 1회 실행:
    ```
-   python3 scripts/prepare_monolith_input.py --run-dir _workspace/{run_id} --genre {genre}
+   python3 ${SKILL_ROOT}/scripts/prepare_monolith_input.py --run-dir _workspace/{run_id} --genre {genre}
    ```
    - `--genre` 값은 영문 키: `essay | column | report | blog | abstract` (생략 시 `essay`). 장르 힌트 매핑: 칼럼→`column`, 리포트→`report`, 블로그→`blog`, 공적/기타→`essay`.
    - `--run-dir`·`--diagnosis`의 상대 경로는 **cwd 기준**으로 해석된다(위 run_id 규칙과 동일 기준). 그 외 인자: `--text`(run-dir 없이 즉석 실행 시 새 run 디렉토리 자동 생성), `--baseline`(baseline JSON 경로 override, 평소 불필요), `--diagnosis`(진단 텍스트 파일을 점수 블록 앞에 prepend — standard·heavy의 진단 결합용).
@@ -81,7 +101,7 @@ humanize-korean v2.3 — 경로: {light|standard|heavy} ({route_hint|사용자 �
    - 진단은 span을 세지 않는다. "무엇이 이 글을 지배하는가"를 판단한다(안정적).
 2. shim으로 진단을 monolith 입력 앞에 결합 (Bash — LLM 콜 아님):
    ```
-   python3 scripts/prepare_monolith_input.py --run-dir _workspace/{run_id} --genre {genre} --diagnosis _workspace/{run_id}/02_diagnosis.md
+   python3 ${SKILL_ROOT}/scripts/prepare_monolith_input.py --run-dir _workspace/{run_id} --genre {genre} --diagnosis _workspace/{run_id}/02_diagnosis.md
    ```
    → `01_input_with_metrics.txt`가 [진단 → 정량 블록 → 원문] 순으로 재생성된다.
 3. **윤문 1콜**: `humanize-monolith` 1회 호출 — **청킹 없음. 1만자급도 단일 콜이다.** → `final.md`.
@@ -100,7 +120,7 @@ Standard의 1과 동일 — `humanize-diagnostician` 1콜 → `02_diagnosis.md`.
 ### Phase P2: 겨냥 윤문
 1. shim으로 진단 결합 (Bash). **heavy에서만** `--chunk`를 함께 줄 수 있다:
    ```
-   python3 scripts/prepare_monolith_input.py --run-dir _workspace/{run_id} --genre {genre} --diagnosis _workspace/{run_id}/02_diagnosis.md --chunk
+   python3 ${SKILL_ROOT}/scripts/prepare_monolith_input.py --run-dir _workspace/{run_id} --genre {genre} --diagnosis _workspace/{run_id}/02_diagnosis.md --chunk
    ```
    - 분할 여부·경계는 100% shim(Python)이 정한다(문단·문장 경계, 헤딩 승격, 말미 각주 passthrough — 청킹 임계는 shim 관리).
    - 산출: `01_chunk_{NN}_input_with_metrics.txt` N개 + `chunk_manifest.json`.
@@ -109,7 +129,7 @@ Standard의 1과 동일 — `humanize-diagnostician` 1콜 → `02_diagnosis.md`.
 4. **청크 병렬(shim이 실제로 쪼갠 경우만)**:
    - 각 body 청크를 monolith로 **병렬 호출**(동시 최대 4). 입력·출력 파일명은 manifest의 **`input_file`·`rewritten_file` 필드를 그대로** 사용한다 — 파일명을 직접 조립하지 않는다(인덱싱 불일치 사고 방지).
    - 각 청크 콜은 같은 `quick_rules_path`(파일 참조)와 같은 `02_diagnosis.md`를 공유한다. **룰북·진단 전문을 청크 프롬프트에 복붙하지 않는다** — 재로드 비용이 청킹 토큰 폭발의 주범이었다(§설계 노트).
-   - 재조립: `python3 scripts/reassemble_chunks.py --run-dir _workspace/{run_id}` → `03_reassembled.md`(passthrough 원문 삽입 + 문자수 대사). 이걸 `final.md`로 삼는다.
+   - 재조립: `python3 ${SKILL_ROOT}/scripts/reassemble_chunks.py --run-dir _workspace/{run_id}` → `03_reassembled.md`(passthrough 원문 삽입 + 문자수 대사). 이걸 `final.md`로 삼는다.
    - 청크 경계 문체 이음매가 어색하면 경계 전후 2문단만 monolith로 국소 패치(전역 재작성 금지 — 의미 드리프트 유발).
    - **재청킹 주의**: `--chunk` 재실행 시 경계가 바뀌므로 기존 `02_chunk_*_rewritten.txt`는 shim이 자동 삭제한다(`stale_removed`). 청킹 후 입력을 수정하면 재청킹부터 다시 한다.
 
@@ -146,7 +166,7 @@ monolith가 자체 보고한 변경률은 **참고값**이다. 철칙 #4의 게�
 윤문본이 나온 직후 Bash로 1회 실행:
 
 ```
-python3 scripts/verify_gates.py \
+python3 ${SKILL_ROOT}/scripts/verify_gates.py \
     --before _workspace/{run_id}/01_input.txt \
     --after  _workspace/{run_id}/final.md \
     --genre {genre}

--- a/scripts/build_diagnosis_rules.py
+++ b/scripts/build_diagnosis_rules.py
@@ -248,5 +248,14 @@ def main(argv: list[str] | None = None) -> int:
     return 0
 
 
+# ── 콘솔 하드닝 (#84) ───────────────────────────────────────────────
+# Windows(cp949)에서 한글·em-dash 출력이 UnicodeEncodeError 로 죽는 것을 막는다.
+import os as _os  # noqa: E402
+import sys as _sys  # noqa: E402
+
+_sys.path.insert(0, _os.path.dirname(_os.path.abspath(__file__)))
+import console as _console  # noqa: E402
+
 if __name__ == "__main__":
+    _console.force_utf8_console()
     sys.exit(main())

--- a/scripts/build_quick_rules.py
+++ b/scripts/build_quick_rules.py
@@ -199,5 +199,14 @@ def main(argv: list[str] | None = None) -> int:
     return 0
 
 
+# ── 콘솔 하드닝 (#84) ───────────────────────────────────────────────
+# Windows(cp949)에서 한글·em-dash 출력이 UnicodeEncodeError 로 죽는 것을 막는다.
+import os as _os  # noqa: E402
+import sys as _sys  # noqa: E402
+
+_sys.path.insert(0, _os.path.dirname(_os.path.abspath(__file__)))
+import console as _console  # noqa: E402
+
 if __name__ == "__main__":
+    _console.force_utf8_console()
     sys.exit(main())

--- a/scripts/checks.py
+++ b/scripts/checks.py
@@ -428,5 +428,14 @@ def main(argv: list[str]) -> int:
     return 0
 
 
+# ── 콘솔 하드닝 (#84) ───────────────────────────────────────────────
+# Windows(cp949)에서 한글·em-dash 출력이 UnicodeEncodeError 로 죽는 것을 막는다.
+import os as _os  # noqa: E402
+import sys as _sys  # noqa: E402
+
+_sys.path.insert(0, _os.path.dirname(_os.path.abspath(__file__)))
+import console as _console  # noqa: E402
+
 if __name__ == "__main__":
+    _console.force_utf8_console()
     raise SystemExit(main(sys.argv))

--- a/scripts/console.py
+++ b/scripts/console.py
@@ -1,0 +1,58 @@
+"""콘솔 출력 하드닝 — Windows(cp949)에서 게이트가 죽는 것을 막는다. (#84)
+
+## 왜 필요한가
+
+한국어 Windows 콘솔의 기본 인코딩은 `cp949`다. 이 저장소의 스크립트는 stdout에
+한글과 em-dash(`—`, U+2014)를 찍는데, cp949는 U+2014를 인코딩하지 못해
+**첫 print에서 UnicodeEncodeError로 즉사한다.**
+
+파일 I/O는 전부 `encoding="utf-8"`을 명시하고 있어 데이터 손상은 없다.
+순수하게 stdout만의 문제다.
+
+## 더 위험한 부분 — exit code 충돌
+
+파이썬은 처리되지 않은 예외에서 **exit 1**로 끝난다. 그런데 게이트 계약에서
+1은 "경고(변경률 30~50%)"다. 즉 **검증이 죽었는데 경고로 읽힌다.**
+검증 실패가 정상 판정으로 둔갑하는 것이 이 저장소가 가장 경계하는 실패 형태다
+(#59의 "조용히 한 축이 죽는다"와 같은 계열).
+
+`run_gate()`가 예외를 잡아 계약상 "실행 오류"인 **exit 3**으로 보낸다.
+"""
+
+from __future__ import annotations
+
+import sys
+import traceback
+from typing import Callable
+
+
+def force_utf8_console() -> None:
+    """stdout·stderr를 UTF-8로 재설정한다. 실패해도 조용히 통과한다.
+
+    errors="replace" — 재설정이 안 되는 환경에서도 죽지 않고 대체 문자로 넘긴다.
+    출력이 조금 깨지는 것이 검증이 통째로 죽는 것보다 낫다.
+    """
+    for stream in (sys.stdout, sys.stderr):
+        reconfigure = getattr(stream, "reconfigure", None)
+        if reconfigure is None:
+            continue
+        try:
+            reconfigure(encoding="utf-8", errors="replace")
+        except (ValueError, OSError):
+            pass  # 파이프·리다이렉트 등 재설정 불가 환경
+
+
+def run_gate(main: Callable[[], int], *, error_exit_code: int = 3) -> int:
+    """게이트 main()을 감싸 콘솔을 하드닝하고 예외를 실행 오류 코드로 보낸다.
+
+    exit 1(경고)과 구분되어야 하므로 기본값은 3(실행 오류)이다.
+    """
+    force_utf8_console()
+    try:
+        return main()
+    except SystemExit:
+        raise
+    except BaseException as exc:  # noqa: BLE001 — 어떤 예외든 3으로 보내는 것이 목적
+        print(f"[gate] 실행 오류 — {type(exc).__name__}: {exc}", file=sys.stderr)
+        traceback.print_exc()
+        return error_exit_code

--- a/scripts/eval_baseline.py
+++ b/scripts/eval_baseline.py
@@ -278,5 +278,14 @@ def main(argv: list[str] | None = None) -> int:
     return 0
 
 
+# ── 콘솔 하드닝 (#84) ───────────────────────────────────────────────
+# Windows(cp949)에서 한글·em-dash 출력이 UnicodeEncodeError 로 죽는 것을 막는다.
+import os as _os  # noqa: E402
+import sys as _sys  # noqa: E402
+
+_sys.path.insert(0, _os.path.dirname(_os.path.abspath(__file__)))
+import console as _console  # noqa: E402
+
 if __name__ == "__main__":
+    _console.force_utf8_console()
     raise SystemExit(main())

--- a/scripts/eval_compare.py
+++ b/scripts/eval_compare.py
@@ -181,5 +181,14 @@ def main(argv: list[str] | None = None) -> int:
     return 0
 
 
+# ── 콘솔 하드닝 (#84) ───────────────────────────────────────────────
+# Windows(cp949)에서 한글·em-dash 출력이 UnicodeEncodeError 로 죽는 것을 막는다.
+import os as _os  # noqa: E402
+import sys as _sys  # noqa: E402
+
+_sys.path.insert(0, _os.path.dirname(_os.path.abspath(__file__)))
+import console as _console  # noqa: E402
+
 if __name__ == "__main__":
+    _console.force_utf8_console()
     raise SystemExit(main())

--- a/scripts/prepare_monolith_input.py
+++ b/scripts/prepare_monolith_input.py
@@ -908,5 +908,14 @@ def main(argv: list[str] | None = None) -> int:
     return 0
 
 
+# ── 콘솔 하드닝 (#84) ───────────────────────────────────────────────
+# Windows(cp949)에서 한글·em-dash 출력이 UnicodeEncodeError 로 죽는 것을 막는다.
+import os as _os  # noqa: E402
+import sys as _sys  # noqa: E402
+
+_sys.path.insert(0, _os.path.dirname(_os.path.abspath(__file__)))
+import console as _console  # noqa: E402
+
 if __name__ == "__main__":
+    _console.force_utf8_console()
     sys.exit(main())

--- a/scripts/reassemble_chunks.py
+++ b/scripts/reassemble_chunks.py
@@ -164,5 +164,14 @@ def main(argv: list[str] | None = None) -> int:
     return 0
 
 
+# ── 콘솔 하드닝 (#84) ───────────────────────────────────────────────
+# Windows(cp949)에서 한글·em-dash 출력이 UnicodeEncodeError 로 죽는 것을 막는다.
+import os as _os  # noqa: E402
+import sys as _sys  # noqa: E402
+
+_sys.path.insert(0, _os.path.dirname(_os.path.abspath(__file__)))
+import console as _console  # noqa: E402
+
 if __name__ == "__main__":
+    _console.force_utf8_console()
     sys.exit(main())

--- a/scripts/sanitize_text.py
+++ b/scripts/sanitize_text.py
@@ -283,5 +283,14 @@ def _main(argv: list[str] | None = None) -> int:
     return 0
 
 
+# ── 콘솔 하드닝 (#84) ───────────────────────────────────────────────
+# Windows(cp949)에서 한글·em-dash 출력이 UnicodeEncodeError 로 죽는 것을 막는다.
+import os as _os  # noqa: E402
+import sys as _sys  # noqa: E402
+
+_sys.path.insert(0, _os.path.dirname(_os.path.abspath(__file__)))
+import console as _console  # noqa: E402
+
 if __name__ == "__main__":
+    _console.force_utf8_console()
     raise SystemExit(_main())

--- a/scripts/verify_change_rate.py
+++ b/scripts/verify_change_rate.py
@@ -97,5 +97,13 @@ def main(argv: list[str] | None = None) -> int:
     return code
 
 
+# ── 콘솔 하드닝 (#84) ───────────────────────────────────────────────
+# Windows(cp949)에서 한글·em-dash 출력이 UnicodeEncodeError 로 죽는 것을 막는다.
+import os as _os  # noqa: E402
+import sys as _sys  # noqa: E402
+
+_sys.path.insert(0, _os.path.dirname(_os.path.abspath(__file__)))
+import console as _console  # noqa: E402
+
 if __name__ == "__main__":
-    sys.exit(main())
+    _sys.exit(_console.run_gate(main))

--- a/scripts/verify_gates.py
+++ b/scripts/verify_gates.py
@@ -258,5 +258,13 @@ def main(argv: list[str] | None = None) -> int:
     return code
 
 
+# ── 콘솔 하드닝 (#84) ───────────────────────────────────────────────
+# Windows(cp949)에서 한글·em-dash 출력이 UnicodeEncodeError 로 죽는 것을 막는다.
+import os as _os  # noqa: E402
+import sys as _sys  # noqa: E402
+
+_sys.path.insert(0, _os.path.dirname(_os.path.abspath(__file__)))
+import console as _console  # noqa: E402
+
 if __name__ == "__main__":
-    sys.exit(main())
+    _sys.exit(_console.run_gate(main))

--- a/tests/test_console_encoding.py
+++ b/tests/test_console_encoding.py
@@ -1,0 +1,148 @@
+"""Windows(cp949) 콘솔에서 게이트가 죽지 않는지 검증 (#84).
+
+## 배경
+
+한국어 Windows 콘솔 기본 인코딩은 cp949 다. 게이트는 stdout 에 한글과
+em-dash(U+2014)를 찍는데 cp949 는 U+2014 를 인코딩하지 못해 **첫 print 에서
+UnicodeEncodeError 로 즉사**했다.
+
+더 위험한 건 exit code 다. 파이썬은 미처리 예외에서 exit 1 로 끝나는데,
+게이트 계약에서 1 은 "경고(변경률 30~50%)" 다. 즉 **검증이 죽었는데 경고로
+읽힌다.** 검증 실패가 정상 판정으로 둔갑하는 것이 이 저장소가 가장 경계하는
+실패 형태다(#59 의 "조용히 한 축이 죽는다"와 같은 계열).
+
+이 테스트는 `PYTHONIOENCODING=cp949` 로 그 환경을 실제로 재현한다.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+_ROOT = Path(__file__).resolve().parent.parent
+_SCRIPTS = _ROOT / "scripts"
+
+BEFORE = "원문은 이러하다. 수치는 1,200명이다."
+AFTER = "원문은 이렇다. 수치는 1,200명이다."
+
+
+def _cp949_env() -> dict:
+    env = dict(os.environ)
+    env["PYTHONIOENCODING"] = "cp949"
+    return env
+
+
+class ConsoleEncodingTests(unittest.TestCase):
+    def test_verify_gates_survives_cp949(self) -> None:
+        """cp949 콘솔에서도 게이트 전 축이 출력되고 정상 종료해야 한다."""
+        with tempfile.TemporaryDirectory() as td:
+            d = Path(td)
+            (d / "b.txt").write_text(BEFORE, encoding="utf-8")
+            (d / "a.txt").write_text(AFTER, encoding="utf-8")
+            proc = subprocess.run(
+                [sys.executable, str(_SCRIPTS / "verify_gates.py"),
+                 "--before", str(d / "b.txt"), "--after", str(d / "a.txt")],
+                capture_output=True, text=True, env=_cp949_env(), timeout=120,
+            )
+        self.assertNotIn("UnicodeEncodeError", proc.stderr)
+        self.assertIn("[P0", proc.stdout)
+        self.assertIn("[P3 golden]", proc.stdout, "golden 축이 출력돼야 함")
+        self.assertIn(proc.returncode, (0, 1, 2), f"예상치 못한 종료 {proc.returncode}")
+
+    def test_missing_input_exits_3_not_1(self) -> None:
+        """실행 오류는 exit 3 — 경고(1)와 반드시 구분돼야 한다."""
+        proc = subprocess.run(
+            [sys.executable, str(_SCRIPTS / "verify_gates.py"),
+             "--before", "/nonexistent/b.txt", "--after", "/nonexistent/a.txt"],
+            capture_output=True, text=True, timeout=60,
+        )
+        self.assertEqual(proc.returncode, 3, "입력 부재는 3(실행 오류)이어야 함")
+
+    def test_run_gate_maps_exception_to_3(self) -> None:
+        """미처리 예외가 exit 1(경고)로 새지 않아야 한다 — 이게 핵심 회귀다."""
+        sys.path.insert(0, str(_SCRIPTS))
+        import console  # noqa: PLC0415
+
+        def boom() -> int:
+            raise RuntimeError("시뮬레이션")
+
+        self.assertEqual(console.run_gate(boom), 3)
+
+    def test_all_korean_printing_scripts_are_hardened(self) -> None:
+        """한글을 찍는 런타임 스크립트는 전부 콘솔 하드닝을 걸어야 한다."""
+        targets = [
+            "verify_gates.py", "verify_change_rate.py", "prepare_monolith_input.py",
+            "reassemble_chunks.py", "checks.py", "build_quick_rules.py",
+            "build_diagnosis_rules.py", "sanitize_text.py",
+        ]
+        missing = []
+        for name in targets:
+            p = _SCRIPTS / name
+            if not p.is_file():
+                continue
+            if "_console" not in p.read_text(encoding="utf-8"):
+                missing.append(name)
+        self.assertEqual(missing, [], f"콘솔 하드닝 누락: {missing}")
+
+
+if __name__ == "__main__":
+    unittest.main()
+
+
+class SkillRootDerivationTests(unittest.TestCase):
+    """SKILL.md 의 SKILL_ROOT 유도가 심링크·플러그인 양쪽에서 성립하는지 (#84-①).
+
+    scripts/ 는 설치 루트에 있고 cwd 는 사용자 작업 디렉터리다. 마켓플레이스
+    설치에서 둘은 절대 일치하지 않아, cwd 상대경로 호출은 항상 실패했다.
+    """
+
+    DERIVE = 'cd -P "$CLAUDE_SKILL_DIR" && cd ../../.. && pwd'
+
+    def _derive(self, skill_dir: Path) -> str:
+        proc = subprocess.run(
+            ["bash", "-c", self.DERIVE],
+            capture_output=True, text=True,
+            env={**os.environ, "CLAUDE_SKILL_DIR": str(skill_dir)}, timeout=30,
+        )
+        return proc.stdout.strip()
+
+    def test_derivation_works_for_plugin_layout(self) -> None:
+        """복사·플러그인 설치(실디렉터리) 레이아웃."""
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td) / "install-root"
+            (root / ".claude" / "skills" / "humanize-korean").mkdir(parents=True)
+            (root / "scripts").mkdir()
+            (root / "scripts" / "prepare_monolith_input.py").touch()
+            got = self._derive(root / ".claude" / "skills" / "humanize-korean")
+            self.assertTrue(
+                (Path(got) / "scripts" / "prepare_monolith_input.py").is_file(),
+                f"플러그인 레이아웃에서 유도 실패: {got}",
+            )
+
+    def test_derivation_works_for_symlink_install(self) -> None:
+        """심링크 설치 — `cd -P` 없이는 홈 디렉터리로 올라가 실패하던 케이스."""
+        with tempfile.TemporaryDirectory() as td:
+            home = Path(td) / "home"
+            (home / ".claude" / "skills").mkdir(parents=True)
+            link = home / ".claude" / "skills" / "humanize-korean"
+            link.symlink_to(_ROOT / ".claude" / "skills" / "humanize-korean")
+            got = self._derive(link)
+            self.assertEqual(
+                Path(got).resolve(), _ROOT.resolve(),
+                f"심링크 설치에서 유도 실패: {got} (cd -P 누락 의심)",
+            )
+
+    def test_skill_md_uses_absolute_script_paths(self) -> None:
+        """SKILL.md 에 cwd 상대 `python3 scripts/` 호출이 남아 있으면 안 된다."""
+        skill = (_ROOT / ".claude" / "skills" / "humanize-korean" / "SKILL.md").read_text(
+            encoding="utf-8"
+        )
+        self.assertNotIn(
+            "python3 scripts/", skill,
+            "cwd 상대 스크립트 호출 잔존 — ${SKILL_ROOT}/scripts/ 를 써야 함",
+        )
+        self.assertIn("cd -P", skill, "심링크 안전 유도(cd -P)가 명시돼야 함")


### PR DESCRIPTION
@pkk0217 님이 Windows + 마켓플레이스 설치에서 light 경로를 **end-to-end 로 완주하며** 찾아주신 2건입니다. 둘 다 SKILL.md 지시를 그대로 따랐을 때 재현됩니다.

## ② cp949 콘솔에서 게이트 즉사 — 더 위험한 쪽

한국어 Windows 콘솔 기본 인코딩은 `cp949` 인데 게이트는 stdout 에 한글과 em-dash(U+2014)를 찍습니다. cp949 는 U+2014 를 인코딩하지 못해 **첫 print 에서 죽습니다.**

**진짜 문제는 exit code 입니다.** 파이썬은 미처리 예외에서 `exit 1` 로 끝나는데, 게이트 계약에서 1 은 **"경고(변경률 30~50%)"** 입니다. 즉 **검증이 죽었는데 경고로 읽힙니다.** 지적하신 그대로입니다 — 검증 실패가 정상 판정으로 둔갑하는 건 이 저장소가 가장 경계하는 실패 형태입니다([#59](https://github.com/epoko77-ai/im-not-ai/issues/59) 의 "조용히 한 축이 죽는다"와 같은 계열).

`scripts/console.py` 를 신설했습니다. stdout·stderr 를 UTF-8 로 재설정하고, `run_gate()` 가 예외를 계약상 실행 오류인 **exit 3** 으로 보냅니다. 한글을 찍는 런타임 스크립트 10종에 적용했습니다.

실측 — `PYTHONIOENCODING=cp949` 로 재현:

```
수정 전: UnicodeEncodeError: 'cp949' codec can't encode character '—'
수정 후: [P0 문자율] 6.7% [전문] — OK
        [P3 golden] PASS
        gate: OK — 수렴          exit=0
내부 예외 주입 → exit=3 (경고 1과 구분됨)
```

## ① scripts/ 를 cwd 상대경로로 호출

지적하신 대로 [#71](https://github.com/epoko77-ai/im-not-ai/issues/71) 이 `--run-dir` 만 cwd 기준으로 고치면서 **같은 명령줄에 두 기준이 섞여** 있었습니다. SKILL.md 5곳을 절대경로로 바꾸고 유도 규칙을 명문화했습니다.

```bash
SKILL_ROOT="$(cd -P "${CLAUDE_SKILL_DIR}" && cd ../../.." && pwd)"
```

**`cd -P` 가 핵심이었습니다.** 제안해주신 "상위 N단계" 방식을 그대로 초안에 넣었다가 심링크 설치에서 홈 디렉터리로 올라가는 걸 실측으로 잡았습니다 — 심링크 설치에서는 스킬 디렉터리가 저장소를 가리키는 심링크라 셸이 논리 경로를 유지합니다. `-P` 로 물리 경로를 먼저 풀어야 심링크·플러그인 양쪽에서 같은 답이 나옵니다.

`CLAUDE_PLUGIN_ROOT` 가 Bash 도구 안에서 비어 있다는 것까지 확인해 주신 덕에 그 경로를 처음부터 배제할 수 있었습니다. 유도가 실패하면 **조용히 건너뛰지 말고 사용자에게 알리도록** 명시했습니다 — 그러지 않으면 route_hint 와 철칙 #4 게이트가 사라진 걸 아무도 모릅니다.

## 테스트

`tests/test_console_encoding.py` 7건 — cp949 실제 재현 · exit 3 매핑 · 하드닝 누락 검사 · **심링크와 플러그인 양쪽** SKILL_ROOT 유도 · SKILL.md 상대경로 잔존 검사.

pytest **230 passed**.

---

Windows 환경에서 end-to-end 로 완주해 주신 덕에 두 건 다 잡혔습니다. 특히 exit code 충돌은 증상만 봐서는 "경고가 떴네" 로 넘어갈 수 있던 것이라, 그 지점을 짚어주신 게 결정적이었습니다.

Closes #84