### PR TITLE
fix(paths): 진단 룰북·참고자료 경로가 cwd 로 풀려 로드 실패

### DIFF
--- a/.claude/skills/humanize-korean/SKILL.md
+++ b/.claude/skills/humanize-korean/SKILL.md
@@ -8,7 +8,7 @@ description: AI(ChatGPT·Claude·Gemini 등)가 쓴 한글 텍스트를 "사람�
 
 > **v2.3.1** — 경로 해석·런타임 경계·계약 정합 수정 회차(외부 제보 반영). 기능 변경 없음.
 > **v2.3.0** — 구조 수렴 게이트(`verify_gates.py` 4축: 목표달성·대구 전멸·수치·golden) + 진단 슬림 인덱스(`diagnosis-rules.md`, taxonomy 83%↓). (v2.2: route_hint 3경로 + 단일 콜 우선)
-> 버전 히스토리·실측 근거·테스트 시나리오: [`references/design-notes.md`](references/design-notes.md)
+> 버전 히스토리·실측 근거·테스트 시나리오: [`${CLAUDE_SKILL_DIR}/references/design-notes.md`](references/design-notes.md)
 
 ## Phase 0: 컨텍스트 확인 및 경로 결정
 
@@ -46,6 +46,8 @@ humanize-korean v2.3 — 경로: {light|standard|heavy} ({route_hint|사용자 �
 ## 스크립트 경로 규칙 (`${SKILL_ROOT}`)
 
 **스크립트는 절대경로로 부른다. cwd 기준 상대경로로 부르면 안 된다.**
+
+`references/*` 는 **스킬 디렉터리** 기준이라 `${CLAUDE_SKILL_DIR}` 를 쓴다 — `${SKILL_ROOT}` 와 기준이 다르니 섞지 않는다. 룰북·taxonomy 경로도 맨앞 접두어 없이 쓰면 cwd 로 풀려 `No such file or directory` 가 난다.
 
 `scripts/*.py`는 설치 루트에 있고 cwd 는 사용자 작업 디렉터리다. 마켓플레이스 설치에서 둘은 **절대 일치하지 않는다.** 반면 `_workspace/` 같은 데이터 경로는 cwd 기준이다(run_id 규칙 참조). 두 기준이 한 명령줄에 섞이므로 스크립트 쪽만 절대경로로 고정한다.
 
@@ -96,7 +98,7 @@ SKILL_ROOT="$(cd -P "${CLAUDE_SKILL_DIR}" && cd ../../.. && pwd)"
 ## Standard 경로 (2콜) — 보통의 AI 초안
 
 1. **진단 1콜**: `humanize-diagnostician`을 `Agent` 도구로 1회 호출.
-   - 입력: `input_path=01_input_with_metrics.txt`, `taxonomy_path=references/diagnosis-rules.md` (진단 전용 슬림 인덱스 — 71패턴 전수, taxonomy에서 자동 생성)
+   - 입력: `input_path=01_input_with_metrics.txt`, `taxonomy_path=${CLAUDE_SKILL_DIR}/references/diagnosis-rules.md` (진단 전용 슬림 인덱스 — 71패턴 전수, taxonomy에서 자동 생성)
    - 출력: `02_diagnosis.md` — 글 전체의 **지배 패턴 3~6개**(본진 ID + 근거 + 처방) + 장르·격식 + 보존 지침.
    - 진단은 span을 세지 않는다. "무엇이 이 글을 지배하는가"를 판단한다(안정적).
 2. shim으로 진단을 monolith 입력 앞에 결합 (Bash — LLM 콜 아님):
@@ -263,7 +265,7 @@ exit code로 분기한다 (0/1/2/3 의미는 기존 게이트와 동일):
 **유지보수 1종 (별도 명령으로만 트리거)**
 - `korean-ai-tell-taxonomist` — 분류 체계(SSOT) 유지·확장. 본 스킬 실행 중에는 호출되지 않음
 
-(개발용 1회성 5종·v2.1 은퇴 5종의 계보와 테스트 시나리오는 `references/design-notes.md` 참조.)
+(개발용 1회성 5종·v2.1 은퇴 5종의 계보와 테스트 시나리오는 `${CLAUDE_SKILL_DIR}/references/design-notes.md` 참조.)
 
 ## 주의 사항
 
@@ -279,11 +281,11 @@ exit code로 분기한다 (0/1/2/3 의미는 기존 게이트와 동일):
 
 ## 참고 자료
 
-- 슬림 룰북 (monolith 전용): [`references/quick-rules.md`](references/quick-rules.md) — S1·S2 핵심 패턴 + 자체검증 체크리스트
-- 진단 인덱스 (diagnostician 전용): [`references/diagnosis-rules.md`](references/diagnosis-rules.md) — 71패턴 전수 ID·정의·시그니처. `build_diagnosis_rules.py`가 taxonomy에서 자동 생성(직접 편집 금지)
-- 정량 점수 shim: `scripts/prepare_monolith_input.py` — `references/metrics_v2.py`(실패 시 `metrics.py` fallback) + `references/baseline.json` 기반 사전 점수 + `route_hint` 산출
-- 텍스트 위생: `scripts/sanitize_text.py` — shim이 자동 호출(끄려면 `--no-sanitize`). 제로폭·bidi·특수공백 제거 + 한글 NFD→NFC 정규화를 `01_input.txt`에 반영해 이후 변경률 게이트·diff·글자수가 같은 기준을 쓰게 한다. 결정적 처리, LLM 0콜. 변경이 있으면 `00_sanitize.json` 기록. **AI 워터마크 제거 기능이 아니다** (CLAUDE.md 「AI 워터마킹에 대한 입장」 참조)
-- 분류 체계 본진 (SSOT — 유지보수·taxonomist 전용): [`references/ai-tell-taxonomy.md`](references/ai-tell-taxonomy.md) — 10대분류 × 활성 70 패턴 (+A-17 hold 1건) 전수. 런타임 콜은 이 파일을 직접 읽지 않는다
-- 윤문 처방 (진단 전용): [`references/rewriting-playbook.md`](references/rewriting-playbook.md) — 카테고리별 치환 레시피·장르별 허용 표
-- 학술 인용 외부 SSOT: [`references/scholarship.md`](references/scholarship.md) — v2.0 학자 인용·caveat verbatim 보존
-- 웹 서비스 스펙 (옵션): [`references/web-service-spec.md`](references/web-service-spec.md) — 웹 확장 시 로드
+- 슬림 룰북 (monolith 전용): [`${CLAUDE_SKILL_DIR}/references/quick-rules.md`](references/quick-rules.md) — S1·S2 핵심 패턴 + 자체검증 체크리스트
+- 진단 인덱스 (diagnostician 전용): [`${CLAUDE_SKILL_DIR}/references/diagnosis-rules.md`](references/diagnosis-rules.md) — 71패턴 전수 ID·정의·시그니처. `build_diagnosis_rules.py`가 taxonomy에서 자동 생성(직접 편집 금지)
+- 정량 점수 shim: `${SKILL_ROOT}/scripts/prepare_monolith_input.py` — `${CLAUDE_SKILL_DIR}/references/metrics_v2.py`(실패 시 `metrics.py` fallback) + `${CLAUDE_SKILL_DIR}/references/baseline.json` 기반 사전 점수 + `route_hint` 산출
+- 텍스트 위생: `${SKILL_ROOT}/scripts/sanitize_text.py` — shim이 자동 호출(끄려면 `--no-sanitize`). 제로폭·bidi·특수공백 제거 + 한글 NFD→NFC 정규화를 `01_input.txt`에 반영해 이후 변경률 게이트·diff·글자수가 같은 기준을 쓰게 한다. 결정적 처리, LLM 0콜. 변경이 있으면 `00_sanitize.json` 기록. **AI 워터마크 제거 기능이 아니다** (CLAUDE.md 「AI 워터마킹에 대한 입장」 참조)
+- 분류 체계 본진 (SSOT — 유지보수·taxonomist 전용): [`${CLAUDE_SKILL_DIR}/references/ai-tell-taxonomy.md`](references/ai-tell-taxonomy.md) — 10대분류 × 활성 70 패턴 (+A-17 hold 1건) 전수. 런타임 콜은 이 파일을 직접 읽지 않는다
+- 윤문 처방 (진단 전용): [`${CLAUDE_SKILL_DIR}/references/rewriting-playbook.md`](references/rewriting-playbook.md) — 카테고리별 치환 레시피·장르별 허용 표
+- 학술 인용 외부 SSOT: [`${CLAUDE_SKILL_DIR}/references/scholarship.md`](references/scholarship.md) — v2.0 학자 인용·caveat verbatim 보존
+- 웹 서비스 스펙 (옵션): [`${CLAUDE_SKILL_DIR}/references/web-service-spec.md`](references/web-service-spec.md) — 웹 확장 시 로드

--- a/agents/humanize-diagnostician.md
+++ b/agents/humanize-diagnostician.md
@@ -18,7 +18,7 @@ model: opus
 
 ### 입력
 - `input_path`: `_workspace/{run_id}/01_input_with_metrics.txt` — shim이 만든 결합 입력. **본문 앞에 정량 점수 블록(카운트형 지표 + 본진 ID 힌트)이 이미 붙어 있다.** 이 수치를 진단의 앵커로 삼는다.
-- `taxonomy_path`: `.../references/diagnosis-rules.md` — 진단 전용 슬림 인덱스(71패턴 전수: ID·정의·탐지 시그니처). SSOT `ai-tell-taxonomy.md`에서 자동 생성되며, 진단에 불필요한 예문 전수·처방·버전주석을 뺀 것이다. 전량 taxonomy 로드는 진단 계약(정확한 ID + 지배도)에 불필요.
+- `taxonomy_path`: 오케스트레이터가 전달하는 **절대 경로**(`…/references/diagnosis-rules.md`). 그대로 Read 하며 상대 경로로 바꿔 탐색하지 않는다 — 진단 전용 슬림 인덱스(71패턴 전수: ID·정의·탐지 시그니처). SSOT `ai-tell-taxonomy.md`에서 자동 생성되며, 진단에 불필요한 예문 전수·처방·버전주석을 뺀 것이다. 전량 taxonomy 로드는 진단 계약(정확한 ID + 지배도)에 불필요.
 
 ### 출력
 - `_workspace/{run_id}/02_diagnosis.md` — 지배 패턴 진단(아래 포맷).

--- a/agents/humanize-monolith.md
+++ b/agents/humanize-monolith.md
@@ -11,7 +11,7 @@ model: opus
 ## 동작 원칙 (단일 호출 안에서)
 
 1. **입력 1회 Read**: `_workspace/{run_id}/01_input.txt` (또는 `01_input_with_metrics.txt` — v1.6 input-shim 결합 입력)
-2. **룰북 1회 Read**: `references/quick-rules.md` (~130줄, S1·S2 핵심만)
+2. **룰북 1회 Read**: 인자 `quick_rules_path` 로 받은 **절대 경로**를 그대로 Read (`…/references/quick-rules.md`, ~130줄, S1·S2 핵심만). 상대 경로 `references/quick-rules.md` 는 cwd 기준으로 풀려 실패한다 — 인자가 비었으면 추측 탐색하지 말고 오케스트레이터에 절대 경로를 요구한다.
 3. **메모리 안에서**: 패턴 스캔 → 윤문 → 자체검증 → 등급 채점
 4. **출력 1회 Write**: `final.md` (본문 + `<!-- HUMANIZE-SUMMARY -->` 주석 블록 통합)
 5. **총 도구 호출 3회**. 그 이상 늘어나면 v1.4와 다를 게 없다.


### PR DESCRIPTION
## 문제

#84 에서 `scripts/*.py` 호출은 `${SKILL_ROOT}` 로 절대화됐습니다. 그런데 `references/*` 쪽은 맨앞 접두어가 없는 상대 경로로 남아 있습니다.

```
SKILL.md:99
  - 입력: `input_path=01_input_with_metrics.txt`, `taxonomy_path=references/diagnosis-rules.md`
```

마켓플레이스 설치에서 cwd 는 사용자 작업 디렉터리이고 스킬은 `~/.claude/plugins/cache/...` 아래에 있습니다. 두 경로가 일치하지 않아 `references/diagnosis-rules.md` 는 `No such file or directory` 로 떨어집니다. #84 가 "스크립트 쪽만 절대경로로 고정한다"고 명시한 대로, references 쪽이 남았습니다.

## 재현

플러그인 설치(`/plugin install humanize-korean`) 상태에서 standard 또는 heavy 경로를 태우면 `humanize-diagnostician` 이 taxonomy 로드에 실패합니다. 저희 환경에서는 서브에이전트 3개가 각각 독립적으로 룰북을 못 찾았다고 보고했고, 실패한 뒤에는 스스로 경로를 추측해 주변을 탐색하다 진단 없이 넘어갔습니다.

**조용히 실패하는 게 문제입니다.** 진단이 빠져도 파이프라인은 계속 돌아서 결과물이 나오고, 진단 품질이 떨어진 것을 사용자가 알아채기 어렵습니다. `${SKILL_ROOT}` 절에 이미 같은 취지의 경고("조용히 건너뛰면 route_hint 와 철칙 #4 게이트가 사라진 것을 아무도 모른다")가 있는데, references 경로에는 그 보호가 없습니다.

## 수정

문서만 고쳤습니다. 스크립트·테스트는 손대지 않았습니다.

- `SKILL.md` L99 `taxonomy_path` 를 `${CLAUDE_SKILL_DIR}` 기준으로 교정
- 참고 자료 절의 `references/*`·`scripts/*` 표기를 실행 가능한 경로로 통일. 마크다운 **링크 대상은 상대 경로를 유지**해 GitHub 웹뷰 링크가 그대로 동작합니다
- 경로 규칙 절에 기준이 둘로 나뉜다는 점을 명시 — `${CLAUDE_SKILL_DIR}`(references, 스킬 디렉터리) 와 `${SKILL_ROOT}`(scripts, 설치 루트) 를 섞지 않도록
- `agents/humanize-monolith.md` L14 · `agents/humanize-diagnostician.md` L21 — 인자로 받은 절대 경로를 그대로 Read 하고 상대 경로로 추측 탐색하지 않도록 문구 확정. monolith 는 L37 에서 이미 "인자를 그대로 Read" 라고 하는데 L14 가 상대 경로를 보여주고 있어 서로 어긋나 있었습니다

## 확인

- 플러그인 설치 레이아웃에서 `${CLAUDE_SKILL_DIR}/references/*` 4개 자산 해석 확인
- `cd -P` 로 유도한 `${SKILL_ROOT}/scripts/*` 는 기존대로 동작 확인
- 문서 변경이라 코드 회귀 없음

## 참고

같은 조사 과정에서 `prepare_monolith_input.py` 의 `--run-dir` 상대 경로 기준도 확인했는데, 이미 #84 에서 `Path.cwd()` 로 고쳐져 있었습니다. 저희가 쓰던 2.3.0 캐시에만 남아 있던 문제라 이 PR 범위에서 제외했습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
