### PR TITLE
docs(contributors): @jckproduct-ai · @hyeonsangjeon 등재

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -283,7 +283,25 @@ v1.2 회차 기여는 위 「v1.2 외부 기여자」 항목에 있습니다. �
 
 - [PR #66](https://github.com/epoko77-ai/im-not-ai/pull/66) — 배선 방식(심사 게이트 없는 파일이 quick-rules 보다 높은 우선순위 + 매 세션 임포트)이 SSOT 단일성·슬림성과 충돌해 닫았습니다. **HG-1 콘텐츠 자체는 정확한 관찰**이라 D-5 보강 또는 `estimated` 신규 패턴으로 taxonomy 재제출을 요청드렸습니다.
 
-> (기존 v2.3 섹션 안, `### 검토 중` 앞에 삽입)
+> (기존 v2.3 섹션 안, `### [@jckproduct-ai](https://github.com/jckproduct-ai)
+
+**기여**: [#84](https://github.com/epoko77-ai/im-not-ai/issues/84) 수정이 **절반만 됐다는 것**을 잡아냄. 플러그인 설치 환경에서 직접 태워보고 서브에이전트 3개의 실패 보고까지 확인했습니다.
+
+**반영**:
+- [PR #88](https://github.com/epoko77-ai/im-not-ai/pull/88) — `scripts/*.py` 는 `${SKILL_ROOT}` 로 절대화됐지만 `references/*` 는 상대경로로 남아, 마켓플레이스 설치에서 `humanize-diagnostician` 이 룰북(`references/diagnosis-rules.md`)을 못 찾고 있었습니다.
+- **실패 양상이 더 중요했습니다.** 진단이 로드에 실패하면 스스로 경로를 추측해 탐색하다 **진단 없이 넘어갑니다.** 파이프라인은 계속 돌아 결과물이 나오므로 품질이 떨어진 것을 아무도 모릅니다. `${SKILL_ROOT}` 절에는 "조용히 건너뛰면 아무도 모른다"는 경고를 넣어두고 references 에는 같은 보호를 두지 않은 것이 원인이었습니다.
+- 두 기준을 분리해 명문화한 것이 이 PR 의 핵심입니다 — `${SKILL_ROOT}`(설치 루트, `scripts/*`) vs `${CLAUDE_SKILL_DIR}`(스킬 디렉터리, `references/*`), **섞지 않는다.** monolith 에 "인자가 비었으면 추측 탐색하지 말고 절대 경로를 요구한다"를 넣어 조용한 실패의 원인 자체를 막았습니다.
+- 마크다운 링크 대상은 상대경로로 남겨 GitHub 웹뷰 링크가 깨지지 않게 한 것도 세심했습니다.
+
+### [@hyeonsangjeon](https://github.com/hyeonsangjeon)
+
+**기여**: GitHub Copilot CLI 를 커뮤니티 지원 런타임으로 추가.
+
+**반영**:
+- [PR #65](https://github.com/epoko77-ai/im-not-ai/pull/65) — 루트 `plugin.json` 매니페스트로 Copilot CLI 네이티브 플러그인 설치 지원, README·INSTALL 문서화.
+- 리뷰에서 "마켓플레이스 설치 시 루트 `plugin.json` 과 `.claude-plugin/plugin.json` 중 어느 쪽이 로드되는가" 를 물었는데, **격리된 `COPILOT_HOME` 에 원격 마켓플레이스로 직접 등록해 실행 결과로 답**해 주셨습니다(`loaded_skill=.../codex/skills/humanize-korean`, `remote_skill_matches_codex=true`). 추론이 아니라 실측이었기에 안심하고 받을 수 있었습니다.
+
+### 검토 중` 앞에 삽입)
 
 ### [@hs85-newbie](https://github.com/hs85-newbie)
 
@@ -302,7 +320,7 @@ v1.2 회차 기여는 위 「v1.2 외부 기여자」 항목에 있습니다. �
 
 ### 검토 중
 
-[@eungwonkim](https://github.com/eungwonkim) ([PR #56](https://github.com/epoko77-ai/im-not-ai/pull/56) C-8 발동 조건) · [@nhleeclaw](https://github.com/nhleeclaw) ([PR #60](https://github.com/epoko77-ai/im-not-ai/pull/60) D-8·F-6 신설) · [@hyeonsangjeon](https://github.com/hyeonsangjeon) ([PR #65](https://github.com/epoko77-ai/im-not-ai/pull/65) Copilot CLI) · [@junhwanjang](https://github.com/junhwanjang) ([PR #64](https://github.com/epoko77-ai/im-not-ai/pull/64) commit-ko)
+[@eungwonkim](https://github.com/eungwonkim) ([PR #56](https://github.com/epoko77-ai/im-not-ai/pull/56) C-8 발동 조건) · [@nhleeclaw](https://github.com/nhleeclaw) ([PR #60](https://github.com/epoko77-ai/im-not-ai/pull/60) D-8·F-6 신설) · [@junhwanjang](https://github.com/junhwanjang) ([PR #64](https://github.com/epoko77-ai/im-not-ai/pull/64) commit-ko)
 
 
 ## 이슈로 기여해 주신 분들


### PR DESCRIPTION
방금 머지한 [#88](https://github.com/epoko77-ai/im-not-ai/pull/88)·[#65](https://github.com/epoko77-ai/im-not-ai/pull/65) 기여자를 기록합니다.

**@jckproduct-ai** — 어제 [#84](https://github.com/epoko77-ai/im-not-ai/issues/84) 를 고치면서 **절반만 고쳤다는 것**을 잡아냈습니다. `scripts/*.py` 는 `${SKILL_ROOT}` 로 절대화해놓고 `references/*` 는 상대경로로 남겨, 마켓플레이스 설치에서 진단 에이전트가 룰북을 못 찾고 있었습니다.

실패 양상이 더 중요했습니다 — 로드에 실패하면 **추측 탐색 후 진단 없이 넘어갑니다.** 결과물은 나오니 품질이 떨어진 걸 아무도 모릅니다. 이 저장소가 반복해서 겪은 "조용한 실패" 계열입니다.

**@hyeonsangjeon** — Copilot CLI 지원. 리뷰 질문에 격리 환경 **실측**으로 답해 주셔서 추론이 아닌 근거로 머지할 수 있었습니다.

34명 등재. pytest 232 passed.