### PR TITLE
fix(install): 심링크 사후 검증 — 조용한 copy 전락을 명시 실패로

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -69,18 +69,24 @@ done
 run() { echo "+ $*"; [ "$DRYRUN" = 1 ] || "$@"; }
 
 # rc: 0=대상 비었음(설치 진행) / 1=이미 우리 심링크(스킵) / 2=충돌(거부)
+# 성공 시 옮겨진 백업 경로를 PREPARED_BACKUP 에 남긴다 — 심링크 생성이 뒤에서
+# 실패하면 install_one 이 이 경로로 기존 설치를 원위치 복원한다.
+PREPARED_BACKUP=""
 prepare_target() {
   local dest="$1" src="$2"
+  PREPARED_BACKUP=""
   if [ -L "$dest" ]; then
     if [ "$(readlink "$dest")" = "$src" ]; then
       echo "ok (already linked): $dest"; return 1
     fi
     run mv "$dest" "$dest.bak.$TS"
+    PREPARED_BACKUP="$dest.bak.$TS"
   elif [ -e "$dest" ]; then
     if [ "$FORCE" != 1 ]; then
       echo "refuse: $dest 가 이미 있음 (--force 로 백업 후 덮어쓰기 또는 --copy)"; return 2
     fi
     run mv "$dest" "$dest.bak.$TS"
+    PREPARED_BACKUP="$dest.bak.$TS"
   fi
   return 0
 }
@@ -135,6 +141,22 @@ install_one() {
     symlink) run ln -s "$src" "$dest" ;;
     copy)    run cp -RL "$src" "$dest" ;;   # -L: references 심링크를 실체로 복사
   esac
+  # symlink 모드 사후 검증 — Windows Git Bash(MSYS)는 심링크 생성 권한이 없으면
+  # ln -s 가 조용히 일반 복사로 전락해 exit 0 을 반환한다. dry-run 은 run() 이
+  # 실제 명령을 실행하지 않으므로 검증 대상에서 제외한다(오탐 방지).
+  if [ "$MODE" = symlink ] && [ "$DRYRUN" != 1 ] && [ ! -L "$dest" ]; then
+    run rm -rf "$dest"
+    if [ -n "$PREPARED_BACKUP" ] && [ -e "$PREPARED_BACKUP" ]; then
+      run mv "$PREPARED_BACKUP" "$dest"
+      echo "restored: $dest (기존 설치 복원됨)"
+    fi
+    echo "error: $dest 심링크 생성 실패 — 일반 파일/디렉토리로 조용히 복사됐습니다." >&2
+    echo "  원인: Windows Git Bash(MSYS)는 관리자 권한/개발자 모드 없이 ln -s 를 실행하면" >&2
+    echo "  심링크 대신 일반 복사를 만듭니다." >&2
+    echo "  대안: ① ./install.sh --copy  ② MSYS=winsymlinks:nativestrict 로 재실행  ③ WSL 에서 설치(권장, INSTALL.md 참고)" >&2
+    echo "  참고: 이 항목 이전에 성공한 설치는 그대로 유지됩니다(되돌리지 않음)." >&2
+    return 1
+  fi
   echo "installed: $dest"
 }
 

--- a/tests/test_install_flags.sh
+++ b/tests/test_install_flags.sh
@@ -110,4 +110,34 @@ assert_not_contains "$all_prune_output" "pruned: $TMP_HOME/.claude/agents/quick-
 assert_contains "$all_prune_output" "pruned: $TMP_HOME/.claude/agents/naturalness-reviewer.md"
 rm -rf "$TMP_HOME/.claude"
 
+# ── 실설치 절 — 심링크 사후 검증 (M20) ────────────────────────────────
+# 위 케이스는 전부 --dry-run 이라 run() 이 실제로 실행되지 않아 설치 결과물이
+# 없다(dry-run 은 출력 문자열만 단정 가능). 이 절만 --dry-run 없이 실제로
+# 설치해 [ -L ] 로 심링크 여부를 단정한다.
+#
+# 선행 능력 탐침: 이 환경이 심링크를 만들 수 있는지 먼저 확인한다. 만들 수
+# 없는 환경(예: Windows Git Bash 기본 상태)에서는 install.sh 가 명시 실패로
+# 반응하는 게 정상 동작이지 조용한 심링크 성공이 아니므로, 여기서 성공을
+# 단정하면 그 환경의 기여자 테스트가 통째로 빨개진다 — skip 처리한다.
+SYMLINK_PROBE_DIR="$(mktemp -d)"
+symlink_capable=1
+if ! ln -s "$SYMLINK_PROBE_DIR" "$SYMLINK_PROBE_DIR.link" 2>/dev/null || [ ! -L "$SYMLINK_PROBE_DIR.link" ]; then
+  symlink_capable=0
+fi
+rm -rf "$SYMLINK_PROBE_DIR" "$SYMLINK_PROBE_DIR.link"
+
+if [ "$symlink_capable" = 1 ]; then
+  REAL_TMP_HOME="$(mktemp -d)"
+  mkdir -p "$REAL_TMP_HOME/.claude"
+  env -i HOME="$REAL_TMP_HOME" PATH="$MINIMAL_PATH" bash "$ROOT/install.sh" --claude-only --no-gemini >/dev/null
+  if [ ! -L "$REAL_TMP_HOME/.claude/skills/humanize-korean" ]; then
+    printf 'expected real install to produce a symlink: %s\n' "$REAL_TMP_HOME/.claude/skills/humanize-korean" >&2
+    exit 1
+  fi
+  rm -rf "$REAL_TMP_HOME"
+  echo "real install symlink check passed"
+else
+  echo "skip: 이 환경은 심링크 생성 권한이 없어 실설치 절을 건너뜀 (fail-closed 동작은 install.sh 사후 검증이 담당)"
+fi
+
 echo "install flag tests passed"


### PR DESCRIPTION
관련: #95

## 문제
Windows Git Bash 에서 MSYS `ln -s` 가 심링크 권한 없이 조용히 일반 복사를 만들고 exit 0 을 반환해, symlink 모드 설치가 실패 없이 "installed" 로 완주하면서 정적 사본을 남깁니다(상세는 이슈 참고).

## 변경 (install.sh +22 / tests +30, 삭제 0)
1. `install_one()`: symlink 모드에서 `ln -s` 후 `[ -L "$dest" ]` 사후 검증. 실패하면 복사 잔재를 제거하고, `prepare_target` 이 옮겨 둔 기존 설치(`.bak.<ts>`)를 원위치 복원한 뒤, 원인과 대안(`--copy` / `MSYS=winsymlinks:nativestrict` / WSL)을 안내하고 비0 으로 종료합니다. dry-run 은 실행이 없으므로 검증에서 제외했습니다.
2. `prepare_target()`: 백업 경로를 `PREPARED_BACKUP` 으로 남겨 위 복원이 가능하게 했습니다.
3. `tests/test_install_flags.sh`: 기존 dry-run 케이스는 그대로 두고, 하단에 실설치 절을 신설해 결과가 실제 심링크인지 `[ -L ]` 로 단정합니다. 심링크를 못 만드는 환경은 선행 능력 탐침으로 skip 해서 그런 환경의 기여자 테스트가 빨개지지 않게 했습니다.

## 하위 호환 영향
지금까지 Git Bash 에서 조용한 복사로 "성공"하던 설치가 이제 명시적으로 실패합니다. 그 사용자는 안내대로 `--copy` 를 명시하면 이전과 같은 결과(복사 설치)를 의도된 계약으로 받게 됩니다. 실패 시 기존 설치는 복원되고, 앞서 성공한 항목은 유지됩니다(출력에 명시).

## 대안 설계
fail-closed 대신 "경고 + 복사 폴백 선언"(설치는 계속하되 `installed (copy fallback):` 로 보고)도 가능합니다. 조용한 전락을 없앤다는 목적은 같으니, 그쪽이 프로젝트 방향에 맞으면 리뷰에서 조정하겠습니다.

## 검증
- WSL Ubuntu-24.04: `pytest tests/ --ignore=tests/test_humanize_live.py` + `bash tests/test_install_flags.sh` — 무패치 baseline 대비 회귀 0
- Windows Git Bash 실측: 기본 모드 → 명시 실패 + 기존 설치 복원 확인 · `--copy` → 정상 완주
- fork CI(ubuntu): https://github.com/lumatic2/im-not-ai/actions/runs/32513353680 (tests: success)
