### PR TITLE
refactor(gates): P5를 총수 비교에서 문장쌍 판정으로

### DIFF
--- a/scripts/restore_modality.py
+++ b/scripts/restore_modality.py
@@ -127,6 +127,33 @@ def align(before: list[str], after: list[str]) -> list[tuple[str, str]]:
     return pairs
 
 
+# 되돌릴 원문 문장에서 **카탈로그가 삭제를 지시한 상투구**는 다시 심지 않는다.
+#
+# 왜: 서법을 되돌리면 그 문장의 AI 티도 함께 돌아온다. 실측에서 복원기가
+# "그러므로, 지금이야말로 변화를 추구해야 할 때입니다."를 통째로 되살려,
+# 윤문이 이미 걷어낸 D-1 결산 피벗과 D-6 결말 껍데기가 부활했다
+# (같은 픽스처에서 결산 피벗 잔존이 3회 중 2회). 서법만 되찾고 상투구는 두고 온다.
+#
+# 조건이 둘 다 맞을 때만 벗긴다: ① 카탈로그가 삭제를 지시한 목록에 있고
+# ② **윤문본이 실제로 그것을 걷어냈다**(즉 실행자의 판단을 존중한다).
+# 벗겨서 서법 표지가 사라지면 벗기지 않는다 — 복원의 목적이 서법이기 때문이다.
+CLICHE_STRIP = [
+    re.compile(r"^(?:그러므로|따라서|결론적으로|요약하면|정리하면|이를\s*통해)[,\s]+"),
+    re.compile(r"지금이야말로\s*"),
+    re.compile(r"바야흐로\s*"),
+]
+
+
+def _strip_restored_cliche(before: str, after: str) -> str:
+    out = before
+    for rx in CLICHE_STRIP:
+        if rx.search(out) and not rx.search(after):
+            stripped = rx.sub("", out, count=1).strip()
+            if any(r.search(stripped) for r in MODAL.values()):
+                out = stripped
+    return out
+
+
 def find_losses(before: str, after: str) -> list[dict]:
     """원문 문장의 서법이 짝 문장에서 사라진 경우를 찾는다.
 
@@ -214,8 +241,9 @@ def restore(before: str, after: str) -> tuple[str, list[dict], list[dict]]:
                 }
             )
             continue
-        result = result.replace(loss["after"], loss["before"], 1)
-        restored.append(loss)
+        replacement = _strip_restored_cliche(loss["before"], loss["after"])
+        result = result.replace(loss["after"], replacement, 1)
+        restored.append({**loss, "restored_as": replacement})
     return result, restored, skipped
 
 

--- a/scripts/verify_gates.py
+++ b/scripts/verify_gates.py
@@ -17,9 +17,10 @@ ending_comma -86%, C-8 대구 -75%가 숨어 있었다. 이 스크립트는 문�
     P4 터치율  — 원문 문장 중 after에 그대로 없는 비율 + 수치 소실 관찰.
                  게이트 아님, 보고만 (수치 소실은 문장 병합·표기 통합의
                  정상 부산물일 수 있어 exit code에 기여하지 않는다).
-    P5 서법    — 당위("~해야 한다")·추측("~할 수 있다") 표지 총수가 줄면 WARN.
-                 줄었다 = 필자가 요구·유보한 것을 단정으로 바꿨을 가능성.
-                 I-4 처방은 '이동'만 허용하므로 총수가 보존돼야 정상이다.
+    P5 서법    — 원문·윤문본을 문장 정렬해, 짝 문장에서 당위("~해야 한다")·추측
+                 ("~할 수 있다")이 사라졌으면 WARN. 총수가 아니라 **문장쌍**으로 본다
+                 — 총수는 오검출과 실손실이 상쇄돼 진짜 위반을 가린다.
+                 짝 유사도가 낮은 건은 보고만 하고 exit code에 넣지 않는다.
                  늘어나는 것은 대상 아님(당위 주입은 P3 golden 소관).
 
 Exit code (verify_change_rate.py와 의미 동일):
@@ -332,21 +333,55 @@ def main(argv: list[str] | None = None) -> int:
         print(f"[P4 수치소실] 관찰: {dropped} "
               f"(문장 병합·표기 통합이면 정상 — exit 미반영, 확인 요망)")
 
-    # --- P5 서법 보존 (당위·추측 표지 총수) -------------------------------
+    # --- P5 서법 보존 (문장쌍 판정) ---------------------------------------
+    #
+    # 총수 비교에서 문장쌍 판정으로 바꿨다. 총수는 **위치를 안 보기 때문에 오검출과
+    # 실손실이 서로 상쇄된다** — 윤문이 다른 문장에서 사전 어휘를 우연히 만들어내면
+    # ("재빨리"→"시급히") 진짜 서법 소실이 net 0으로 가려진다. 한 표현이 표지 2개로
+    # 세지는 이중 계수도 있어, 동력을 보존한 정상 윤문이 false WARN을 냈다.
+    #
+    # 문장쌍은 "어느 문장의 어떤 서법이 사라졌는가"를 보므로 상쇄가 구조적으로 불가능하다.
+    # 덤으로 카탈로그 충돌 상당수가 자동 해소된다 — D-2·D-3의 상투구 삭제는 문장이 통째로
+    # 사라지거나 짝이 없어 판정 대상 밖이다(총수 기준에서는 곧바로 위반이었다).
+    #
+    # 정렬 코드는 restore_modality가 이미 갖고 있다(같은 사전을 쓰는 단일 출처).
+    # 순환 import를 피하려고 함수 안에서 늦게 불러온다.
+    from restore_modality import find_losses  # noqa: PLC0415
+
+    losses = find_losses(before, after)
+    confident = [l for l in losses if not l.get("low_sim")]
+    uncertain = [l for l in losses if l.get("low_sim")]
+    modality_fail = len(confident) > MODALITY_TOLERANCE
+    warn = warn or modality_fail
     deo_b, hed_b = count_modality(before)
     deo_a, hed_a = count_modality(after)
-    deo_lost = deo_b - deo_a
-    hed_lost = hed_b - hed_a
-    modality_fail = deo_lost > MODALITY_TOLERANCE or hed_lost > MODALITY_TOLERANCE
-    warn = warn or modality_fail
     report["modality"] = {
-        "deontic": {"before": deo_b, "after": deo_a},
-        "hedge": {"before": hed_b, "after": hed_a},
-        "verdict": ("FAIL — 서법 표지 감소(당위·추측을 단정으로 바꿨을 수 있음)"
+        "lost_pairs": [
+            {"kind": l["kind"], "before": l["before"], "after": l["after"]}
+            for l in confident
+        ],
+        # 짝 유사도가 낮아 같은 문장인지 확신할 수 없는 건은 exit code에 넣지 않는다.
+        # 다만 조용히 버리지도 않는다 — 진짜 소실이 여기 섞여 있을 수 있다(P4와 같은 정책).
+        "uncertain_pairs": [
+            {"kind": l["kind"], "before": l["before"], "after": l["after"]}
+            for l in uncertain
+        ],
+        # 총수는 참고용으로만 남긴다. 판정 근거가 아니다.
+        "counts": {
+            "deontic": {"before": deo_b, "after": deo_a},
+            "hedge": {"before": hed_b, "after": hed_a},
+        },
+        "verdict": (f"FAIL — 서법 소실 {len(confident)}문장"
                     if modality_fail else "OK"),
     }
-    print(f"[P5 서법] 당위 {deo_b} → {deo_a} / 완곡 {hed_b} → {hed_a} — "
+    print(f"[P5 서법] 소실 {len(confident)}문장 "
+          f"(참고 총수: 당위 {deo_b}→{deo_a} / 완곡 {hed_b}→{hed_a}) — "
           f"{report['modality']['verdict']}")
+    for l in confident[:3]:
+        print(f"          [{l['kind']}] {l['before'][:34]} → {l['after'][:34]}")
+    if uncertain:
+        print(f"          관찰: 짝 유사도가 낮아 판정 보류한 건 {len(uncertain)}건 "
+              f"(exit 미반영 — 확인 요망)")
 
     # --- 통합 판정 --------------------------------------------------------
     if abort:

--- a/tests/test_restore_modality.py
+++ b/tests/test_restore_modality.py
@@ -96,6 +96,29 @@ class RestoreModalityTests(unittest.TestCase):
         self.assertTrue(skipped, "조용히 탈락하면 손실 추적이 불가능하다")
         self.assertIn("유사도", skipped[0]["reason"])
 
+    def test_restored_sentence_drops_cliche_the_rewriter_removed(self) -> None:
+        """서법은 되찾되, 윤문이 걷어낸 상투구까지 되살리지는 않는다.
+
+        회귀 방지: 복원기가 "그러므로, 지금이야말로 ~할 때입니다."를 통째로 되살려
+        D-1 결산 피벗과 D-6 결말 껍데기가 부활했다(같은 픽스처 3회 중 2회 재현).
+        """
+        before = "그러므로, 지금이야말로 변화를 추구해야 할 때입니다."
+        after = "지금이 변화를 추구할 시점입니다."
+        out, restored, _ = rm.restore(before, after)
+        self.assertEqual(len(restored), 1)
+        self.assertIn("추구해야", out, "서법은 되돌아와야 한다")
+        self.assertNotIn("그러므로", out)
+        self.assertNotIn("지금이야말로", out)
+
+    def test_keeps_cliche_the_rewriter_kept(self) -> None:
+        """윤문본이 남겨둔 상투구는 실행자의 판단이므로 건드리지 않는다."""
+        before = "따라서 정부는 즉시 대응해야 한다."
+        after = "따라서 정부가 즉시 대응한다."
+        out, restored, _ = rm.restore(before, after)
+        self.assertEqual(len(restored), 1)
+        self.assertIn("따라서", out)
+        self.assertIn("대응해야 한다", out)
+
     def test_ignores_unrelated_sentence_pairs(self) -> None:
         """유사도가 낮은 짝은 정렬 아티팩트 — 서법 판정 대상이 아니다."""
         before = "규제안의 영향은 아직 단정하기 어렵다."

--- a/tests/test_verify_gates.py
+++ b/tests/test_verify_gates.py
@@ -381,6 +381,45 @@ class ModalityGateTests(unittest.TestCase):
             code = verify_gates.main(["--before", b, "--after", a])
         self.assertGreaterEqual(code, 1)
 
+    def test_pairwise_catches_loss_masked_by_offsetting_gain(self) -> None:
+        """상쇄 은폐 — 총수 기준이면 통과하지만 실제로는 서법이 바뀐 경우.
+
+        한 문장에서 유보가 단정으로 바뀌고, 무관한 다른 문장에서 사전 어휘가
+        우연히 생기면 총수는 그대로다. 문장쌍 판정은 이걸 잡아야 한다.
+        """
+        before = "고용 효과는 제한적일 것으로 판단된다. 통계는 다음 주에 나온다."
+        after = "고용 효과는 제한적이다. 통계는 다음 주에 나올 수 있다."
+        # 총수는 상쇄돼 변화 없음 — 옛 기준이라면 통과했다.
+        self.assertEqual(
+            verify_gates.count_modality(before)[1],
+            verify_gates.count_modality(after)[1],
+        )
+        with tempfile.TemporaryDirectory() as d:
+            b = _write(d, "b.md", before)
+            a = _write(d, "a.md", after)
+            code = verify_gates.main(["--before", b, "--after", a])
+        self.assertGreaterEqual(code, 1, "상쇄에 가려진 서법 소실을 놓쳤다")
+
+    def test_pairwise_ignores_deleted_cliche_sentence(self) -> None:
+        """카탈로그가 삭제를 지시한 상투구 문장은 서법 위반이 아니다.
+
+        D-2 "시사하는 바가 크다" 삭제는 총수 기준에서는 곧바로 완곡 감소였다.
+        문장이 통째로 사라지면 짝이 없으므로 문장쌍 판정의 대상이 아니다.
+        """
+        before = (
+            "국내 클라우드 시장은 지난해 크게 성장했다. "
+            "이는 시사하는 바가 크다고 할 수 있다. "
+            "사업자들은 투자를 늘리고 있다."
+        )
+        after = (
+            "국내 클라우드 시장은 지난해 크게 성장했다. "
+            "사업자들은 투자를 늘리고 있다."
+        )
+        from restore_modality import find_losses
+
+        confident = [l for l in find_losses(before, after) if not l.get("low_sim")]
+        self.assertEqual(confident, [], f"삭제된 상투구를 위반으로 셌다: {confident}")
+
     def test_gate_ok_when_modality_kept(self) -> None:
         """이동만 한 경우 P5는 통과한다.
 


### PR DESCRIPTION
## 왜

P5는 당위·완곡 표지의 **총수**를 비교했다. 총수는 위치를 보지 않으므로 **오검출과 실손실이 서로 상쇄된다** — 윤문이 다른 문장에서 사전 어휘를 우연히 만들어내면("재빨리" → "시급히") 진짜 서법 소실이 net 0으로 가려진다. 반대로 한 표현이 표지 2개로 세지는 이중 계수("손봐야 할 때입니다" = 2)는 동력을 보존한 정상 윤문에 false WARN을 냈다.

사전을 정교하게 다듬어도 이 상쇄는 남는다. 계수 방식 자체의 한계다.

## 무엇

판정을 문장쌍으로 바꾼다. "어느 문장의 어떤 서법이 사라졌는가"를 보므로 상쇄가 구조적으로 불가능하다. 정렬 코드는 `restore_modality.py`가 이미 갖고 있어(같은 사전을 쓰는 단일 출처) 계산부만 갈아끼웠다.

**카탈로그 충돌이 함께 해소된다.** D-2 "시사하는 바가 크다" 삭제, D-3 "크게 세 가지로 나눌 수 있다" 삭제는 총수 기준에서 곧바로 완곡 감소였다 — 규칙이 지시한 편집을 게이트가 벌하고 있었다. 문장이 통째로 사라지면 짝이 없으므로 문장쌍 판정의 대상이 아니다.

짝 유사도가 낮아 같은 문장인지 확신할 수 없는 건은 exit code에 넣지 않고 "관찰"로만 보고한다(P4 수치소실과 같은 정책). 조용히 버리지는 않는다. 총수는 참고용으로 리포트에 남긴다.

## 검증

- 새 테스트 2건: 상쇄 은폐(총수 동일인데 유보→단정)가 이제 WARN / 삭제된 상투구 문장은 위반 아님
- 실제 파이프라인(Phase 2.4 복원 → 2.5 게이트): 복원 2문장 후 P5 소실 0, 게이트 OK. 같은 입력이 총수 기준에서는 완곡 7→6으로 false WARN이었다
- `pytest` 259 통과 / 기존 실패 1건(`test_agent_inventory`, main에서도 동일)

https://claude.ai/code/session_01Bc2zvbdNjAS1J1LTiGmMRh