### PR TITLE
fix(metrics): 쉼표 계열 상한 + high 독립 2계열 요건 (Pebblous 반례 수용)

### DIFF
--- a/skills/humanize-korean/references/metrics.py
+++ b/skills/humanize-korean/references/metrics.py
@@ -258,22 +258,33 @@ def _z(value: float, human: float, ai: float, *, percent: bool) -> float | None:
 
 
 def _classify_risk(z_scores: dict[str, float | None], lexicon_hits: dict[str, int]) -> tuple[str, int]:
-    score = 0
+    """오탐 방지 원칙(ai-tell-taxonomy)의 판정기 구현.
+
+    쉼표(C-11) 계열은 필자 개인 습관 편차가 커서 단독으로는 증거가 못 된다
+    — 계열 기여를 3점으로 상한하고, high 는 독립 계열 2개 이상이 동시에
+    발화할 때만 부여한다 (Pebblous 티어다운 2026-08 반례 수용).
+    """
+    punct = 0
     for key in ("comma_inclusion_rate", "ending_comma_rate", "comma_segment_length"):
         z = z_scores.get(key)
         if z is not None and z > 1.0:
-            score += 2
+            punct += 2
+    punct = min(punct, 3)
+    lexical = 0
     ld = z_scores.get("lexical_diversity")
     if ld is not None and ld < -1.0:
-        score += 1
-    if lexicon_hits.get("conclusion_pivot_count", 0) >= 2:
-        score += 1
-    if lexicon_hits.get("safe_balance_count", 0) >= 2:
-        score += 1
+        lexical += 1
     hz = z_scores.get("hanja_nominalizer_density")
     if hz is not None and hz > 1.0:
-        score += 1
-    if score >= 6:
+        lexical += 1
+    rhetoric = 0
+    if lexicon_hits.get("conclusion_pivot_count", 0) >= 2:
+        rhetoric += 1
+    if lexicon_hits.get("safe_balance_count", 0) >= 2:
+        rhetoric += 1
+    score = punct + lexical + rhetoric
+    families = sum(1 for v in (punct, lexical, rhetoric) if v > 0)
+    if score >= 6 and families >= 2:
         band = "high"
     elif score >= 4:
         band = "medium"

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -153,6 +153,36 @@ class MetricsTests(unittest.TestCase):
         result = metrics.compute_all(text, genre="essay", baseline_path=BASELINE_PATH)
         self.assertEqual(result["risk_band"], "low")
 
+    def test_comma_family_alone_cannot_reach_high(self) -> None:
+        # Pebblous 티어다운(2026-08) 반례 — 2020년(pre-ChatGPT) 사람 에세이가
+        # 필자의 쉼표 습관(C-11 계열 z=+10)만으로 6/6 high 판정을 받았다.
+        # 쉼표 계열은 3점 상한이라 단독으로는 low 를 넘을 수 없어야 한다.
+        z = {
+            "comma_inclusion_rate": 10.0,
+            "ending_comma_rate": 10.0,
+            "comma_segment_length": 10.0,
+            "lexical_diversity": 0.0,
+            "hanja_nominalizer_density": 0.0,
+        }
+        band, score = metrics._classify_risk(z, {})
+        self.assertLessEqual(score, 3)
+        self.assertEqual(band, "low")
+
+    def test_high_requires_two_independent_families(self) -> None:
+        # high 는 독립 계열 2개 이상 동시 발화 시에만 — 쉼표 상한 3점에
+        # 수사·어휘 계열이 더해져야 6점에 닿는다.
+        z = {
+            "comma_inclusion_rate": 10.0,
+            "ending_comma_rate": 10.0,
+            "comma_segment_length": 10.0,
+            "lexical_diversity": 0.0,
+            "hanja_nominalizer_density": 2.0,
+        }
+        hits = {"conclusion_pivot_count": 3, "safe_balance_count": 2}
+        band, score = metrics._classify_risk(z, hits)
+        self.assertEqual(band, "high")
+        self.assertEqual(score, 6)
+
     # ------------------------------------------------------------------
     # CLI smoke
     # ------------------------------------------------------------------


### PR DESCRIPTION
## 배경
Pebblous 티어다운(2026-08)이 재현한 오판: 2020년(pre-ChatGPT) 사람 에세이가 필자의 쉼표 습관(C-11 계열 z=+10)만으로 위험도 6/6 high 판정. 쉼표 5개를 지우면 판정이 반전됐다.

v2.6에서 문서 원칙(오탐 방지 절)은 반영됐으나 판정기 코드는 그대로였다 — `_classify_risk`에서 쉼표 계열 3개 지표(각 2점)만으로 high 임계 6점에 도달 가능.

## 변경
- 쉼표(punctuation) 계열 기여 상한 3점
- high는 punctuation / lexical / rhetoric 독립 계열 2개 이상 동시 발화 시에만
- 회귀 테스트 2종: 쉼표 단독 z=+10 → low, 다계열 6점 → high 유지

## 검증
- test_metrics / test_metrics_v2 / test_route_hint 94개 전부 통과
- 기존 high fixture(다계열)는 판정 불변

https://claude.ai/code/session_01Bc2zvbdNjAS1J1LTiGmMRh