### PR TITLE
feat(baseline): column·report 장르 셀 — 실측 인간 극, 역전 지표 비활성

### DIFF
--- a/skills/humanize-korean/references/baseline.json
+++ b/skills/humanize-korean/references/baseline.json
@@ -1,102 +1,327 @@
 {
-  "version": "v1.6-2026-05-06",
-  "source": "KatFish (Park et al., 인간 470 vs LLM 1,624편 / 에세이 771·시 945·초록 378) + LREAD 인간 판독 실험",
-  "notes": "metric-engineer는 이 baseline을 그대로 import해 z-score 계산에 사용한다. 미공개 셀은 null. 사용자 코퍼스로 보강 시 source에 ',user-corpus-{date}' 추가.",
-  "genres": {
-    "essay": {
-      "comma_inclusion_rate": {"human": 26.31, "ai": 61.03, "ratio": 2.32, "unit": "percent"},
-      "comma_usage_rate": {"human": 1.13, "ai": 2.56, "ratio": 2.27, "unit": "per_sentence"},
-      "comma_relative_position": {"human": 0.10, "ai": 0.20, "ratio": 2.00, "unit": "normalized_0to1"},
-      "comma_segment_length": {"human": 4.35, "ai": 8.56, "ratio": 1.97, "unit": "eojeol_per_segment"},
-      "comma_pos_diversity": {"human": 24.38, "ai": 59.39, "ratio": 2.44, "unit": "pos_count"},
-      "ending_comma_rate": {"human": 4.10, "ai": 19.83, "ratio": 4.84, "unit": "percent"}
-    },
-    "poetry": {
-      "comma_inclusion_rate": {"human": 27.01, "ai": 42.90, "ratio": 1.59, "unit": "percent"},
-      "comma_usage_rate": {"human": 2.61, "ai": 4.84, "ratio": 1.85, "unit": "per_sentence"},
-      "comma_relative_position": {"human": 0.18, "ai": 0.27, "ratio": 1.50, "unit": "normalized_0to1"},
-      "comma_segment_length": null,
-      "comma_pos_diversity": {"human": 23.13, "ai": 23.86, "ratio": 1.03, "unit": "pos_count", "note": "시 장르는 분리도 약함 — 장르 가드 필요"},
-      "ending_comma_rate": {"human": 4.68, "ai": 15.57, "ratio": 3.33, "unit": "percent"}
-    },
-    "abstract": {
-      "comma_inclusion_rate": {"human": 47.48, "ai": 65.21, "ratio": 1.37, "unit": "percent"},
-      "comma_usage_rate": {"human": 1.73, "ai": 2.40, "ratio": 1.39, "unit": "per_sentence"},
-      "comma_relative_position": {"human": 0.15, "ai": 0.24, "ratio": 1.60, "unit": "normalized_0to1", "note": "보고서 본문 추정치(상세 셀 미공개)"},
-      "comma_segment_length": null,
-      "comma_pos_diversity": null,
-      "ending_comma_rate": {"human": 13.27, "ai": 28.01, "ratio": 2.11, "unit": "percent"}
-    },
-    "news": null,
-    "qa": null,
-    "blog": null
+ "version": "v1.6-2026-05-06",
+ "source": "KatFish (Park et al., 인간 470 vs LLM 1,624편 / 에세이 771·시 945·초록 378) + LREAD 인간 판독 실험, user-corpus-2026-08-29 (칼럼 11·위키 521 — column/report 셀)",
+ "notes": "metric-engineer는 이 baseline을 그대로 import해 z-score 계산에 사용한다. 미공개 셀은 null. 사용자 코퍼스로 보강 시 source에 ',user-corpus-{date}' 추가.",
+ "genres": {
+  "essay": {
+   "comma_inclusion_rate": {
+    "human": 26.31,
+    "ai": 61.03,
+    "ratio": 2.32,
+    "unit": "percent"
+   },
+   "comma_usage_rate": {
+    "human": 1.13,
+    "ai": 2.56,
+    "ratio": 2.27,
+    "unit": "per_sentence"
+   },
+   "comma_relative_position": {
+    "human": 0.1,
+    "ai": 0.2,
+    "ratio": 2.0,
+    "unit": "normalized_0to1"
+   },
+   "comma_segment_length": {
+    "human": 4.35,
+    "ai": 8.56,
+    "ratio": 1.97,
+    "unit": "eojeol_per_segment"
+   },
+   "comma_pos_diversity": {
+    "human": 24.38,
+    "ai": 59.39,
+    "ratio": 2.44,
+    "unit": "pos_count"
+   },
+   "ending_comma_rate": {
+    "human": 4.1,
+    "ai": 19.83,
+    "ratio": 4.84,
+    "unit": "percent"
+   }
   },
-  "global_average": {
-    "comma_inclusion_rate": {"human": 33.60, "ai": 56.38, "ratio": 1.68, "unit": "percent"},
-    "comma_usage_rate": {"human": 1.82, "ai": 3.27, "ratio": 1.79, "unit": "per_sentence"},
-    "comma_relative_position": {"human": 0.14, "ai": 0.24, "ratio": 1.65, "unit": "normalized_0to1"},
-    "comma_segment_length": {"human": 5.13, "ai": 7.41, "ratio": 1.45, "unit": "eojeol_per_segment"},
-    "comma_pos_diversity": {"human": 30.12, "ai": 48.40, "ratio": 1.61, "unit": "pos_count"}
+  "poetry": {
+   "comma_inclusion_rate": {
+    "human": 27.01,
+    "ai": 42.9,
+    "ratio": 1.59,
+    "unit": "percent"
+   },
+   "comma_usage_rate": {
+    "human": 2.61,
+    "ai": 4.84,
+    "ratio": 1.85,
+    "unit": "per_sentence"
+   },
+   "comma_relative_position": {
+    "human": 0.18,
+    "ai": 0.27,
+    "ratio": 1.5,
+    "unit": "normalized_0to1"
+   },
+   "comma_segment_length": null,
+   "comma_pos_diversity": {
+    "human": 23.13,
+    "ai": 23.86,
+    "ratio": 1.03,
+    "unit": "pos_count",
+    "note": "시 장르는 분리도 약함 — 장르 가드 필요"
+   },
+   "ending_comma_rate": {
+    "human": 4.68,
+    "ai": 15.57,
+    "ratio": 3.33,
+    "unit": "percent"
+   }
   },
-  "z_score_thresholds": {
-    "high_risk": 1.0,
-    "comments": "보고서 §탐지 알고리즘에서 z>1.0 시 가산. 문서별 측정값을 장르 baseline과 비교한 z-score가 1.0 초과면 해당 지표 가산. news/qa/blog는 사용자 코퍼스로 보강 필요. 시 장르는 comma_pos_diversity 분리도가 약하므로 (genre=='poetry') 가드 권장."
+  "abstract": {
+   "comma_inclusion_rate": {
+    "human": 47.48,
+    "ai": 65.21,
+    "ratio": 1.37,
+    "unit": "percent"
+   },
+   "comma_usage_rate": {
+    "human": 1.73,
+    "ai": 2.4,
+    "ratio": 1.39,
+    "unit": "per_sentence"
+   },
+   "comma_relative_position": {
+    "human": 0.15,
+    "ai": 0.24,
+    "ratio": 1.6,
+    "unit": "normalized_0to1",
+    "note": "보고서 본문 추정치(상세 셀 미공개)"
+   },
+   "comma_segment_length": null,
+   "comma_pos_diversity": null,
+   "ending_comma_rate": {
+    "human": 13.27,
+    "ai": 28.01,
+    "ratio": 2.11,
+    "unit": "percent"
+   }
   },
-  "lexicons": {
-    "conclusion_pivot": [
-      "결론적으로",
-      "따라서",
-      "이를 통해",
-      "그러므로"
-    ],
-    "safe_balance": [
-      "양쪽 모두",
-      "두 가지 모두",
-      "장점도 있지만",
-      "신중하게",
-      "균형"
-    ],
-    "hanja_nominalizers": [
-      "성",
-      "적",
-      "화"
-    ],
-    "lexicon_thresholds": {
-      "conclusion_pivot": {"per_doc_count": 3, "severity": "S1", "merges_into": "D-1"},
-      "safe_balance": {"per_doc_count": 4, "severity": "S2", "new_code": "G-3"},
-      "hanja_nominalizers": {"per_doc_density": 12, "severity": "S2", "merges_into": "F-4", "unit": "occurrences_per_doc"}
-    }
+  "news": null,
+  "qa": null,
+  "blog": null,
+  "column": {
+   "_source": "user-corpus-2026-08-29: 저자 칼럼 11편 실측 (클린 게이트 통과분). AI 극은 장르별 AI 코퍼스 미확보로 global(KatFish) 상속",
+   "comma_inclusion_rate": {
+    "human": 37.72,
+    "ai": 61.03,
+    "ratio": 1.62,
+    "unit": "percent"
+   },
+   "comma_usage_rate": {
+    "human": 0.52,
+    "ai": 2.56,
+    "ratio": 4.92,
+    "unit": "per_sentence"
+   },
+   "comma_segment_length": {
+    "human": 7.07,
+    "ai": 8.56,
+    "ratio": 1.21,
+    "unit": "eojeol_per_segment"
+   },
+   "ending_comma_rate": {
+    "human": null,
+    "ai": null,
+    "unit": "percent",
+    "note": "칼럼 인간 실측 41.0% > essay-AI 19.83%. 사용자 코퍼스 실측에서 human이 essay-AI 극을 초과(역전) — 이 장르에선 판별 불가로 비활성"
+   }
   },
-  "lread_calibration": {
-    "human_intuition_acc": 0.60,
-    "human_intuition_p_value": 0.362,
-    "human_intuition_chance_diff": "no statistical difference",
-    "rubric_acc": 0.90,
-    "rubric_fisher_p": 0.015,
-    "rubric_cohens_h": 0.73,
-    "ai_essay_false_negative_drop": {
-      "before": 0.500,
-      "after": 0.083,
-      "fisher_p": 0.003
-    },
-    "zero_shot_llm_majority_acc": 0.9667,
-    "comments": "Phase 1 직관 60%는 chance와 통계적 차이 없음(p=.362) — 일반 독자는 AI 한글 식별 어려움. Phase 2 루브릭(쉼표·연결어미·결산·균형 어휘 등 우리 분류 체계와 정렬)을 제공하면 90%로 급상승. v1.6 detector는 LREAD 루브릭의 측정 지표를 그대로 흡수해 인간 판독 90% 수준 도달이 1차 KPI."
-  },
-  "v1_6_promotion_targets": {
-    "promote": [
-      {"cand_id": "cand-v16-001", "new_code": "C-11", "name": "ending_comma_rate", "severity": "S1", "primary_metric": "ending_comma_rate"},
-      {"cand_id": "cand-v16-002", "new_code": "C-12", "name": "comma_inclusion_rate", "severity": "S2", "primary_metric": "comma_inclusion_rate"},
-      {"cand_id": "cand-v16-003", "new_code": "E-5", "name": "comma_segment_length", "severity": "S2", "primary_metric": "comma_segment_length"},
-      {"cand_id": "cand-v16-004", "new_code": "E-6", "name": "comma_pos_diversity", "severity": "S2", "primary_metric": "comma_pos_diversity", "genre_guard": ["poetry"]},
-      {"cand_id": "cand-v16-007", "new_code": "G-3", "name": "safe_balance_lexicon", "severity": "S2", "primary_metric": "safe_balance"}
-    ],
-    "merge": [
-      {"cand_id": "cand-v16-006", "into": ["D-1", "H-1", "A-2"], "patch": "lexicon 4종 정식 인용 + 임계"},
-      {"cand_id": "cand-v16-008", "into": ["F-4"], "patch": "hanja_nominalizers 3종 명시 + 한 문서 12회 초과 S2 강화 임계"}
-    ],
-    "hold": [
-      {"cand_id": "cand-v16-005", "name": "spacing_regularness", "reason": "보고서 본문에 정량 셀 미공개. 사용자 코퍼스 baseline 확보 후 v1.7 검토. 탐지 전용 신호로만 채용 가능, 윤문 처방 없음(맞춤법 일부러 틀리게 만들지 않음)"},
-      {"cand_id": "cand-v16-009", "name": "persona_register_mismatch", "reason": "v1.5 monolith fast + author-context 미주입과 충돌. 메타 부스터로만 작동하는 옵트인 설계가 정리되면 v1.7+ 검토"}
-    ]
+  "report": {
+   "_source": "user-corpus-2026-08-29: 위키 설명문 521청크 실측 (설명문·정보성 산문 프록시). AI 극은 global(KatFish) 상속",
+   "comma_inclusion_rate": {
+    "human": 50.25,
+    "ai": 61.03,
+    "ratio": 1.21,
+    "unit": "percent",
+    "note": "인간 sd 18.3으로 극간 분리 약함 — 단독 증거 금지(가족 캡이 흡수)"
+   },
+   "comma_usage_rate": {
+    "human": 0.81,
+    "ai": 2.56,
+    "ratio": 3.16,
+    "unit": "per_sentence"
+   },
+   "comma_segment_length": {
+    "human": null,
+    "ai": null,
+    "unit": "eojeol_per_segment",
+    "note": "설명문 인간 실측 9.22 > essay-AI 8.56. 사용자 코퍼스 실측에서 human이 essay-AI 극을 초과(역전) — 이 장르에선 판별 불가로 비활성"
+   },
+   "ending_comma_rate": {
+    "human": null,
+    "ai": null,
+    "unit": "percent",
+    "note": "설명문 인간 실측 32.9% > essay-AI 19.83%. 사용자 코퍼스 실측에서 human이 essay-AI 극을 초과(역전) — 이 장르에선 판별 불가로 비활성"
+   }
   }
+ },
+ "global_average": {
+  "comma_inclusion_rate": {
+   "human": 33.6,
+   "ai": 56.38,
+   "ratio": 1.68,
+   "unit": "percent"
+  },
+  "comma_usage_rate": {
+   "human": 1.82,
+   "ai": 3.27,
+   "ratio": 1.79,
+   "unit": "per_sentence"
+  },
+  "comma_relative_position": {
+   "human": 0.14,
+   "ai": 0.24,
+   "ratio": 1.65,
+   "unit": "normalized_0to1"
+  },
+  "comma_segment_length": {
+   "human": 5.13,
+   "ai": 7.41,
+   "ratio": 1.45,
+   "unit": "eojeol_per_segment"
+  },
+  "comma_pos_diversity": {
+   "human": 30.12,
+   "ai": 48.4,
+   "ratio": 1.61,
+   "unit": "pos_count"
+  }
+ },
+ "z_score_thresholds": {
+  "high_risk": 1.0,
+  "comments": "보고서 §탐지 알고리즘에서 z>1.0 시 가산. 문서별 측정값을 장르 baseline과 비교한 z-score가 1.0 초과면 해당 지표 가산. news/qa/blog는 사용자 코퍼스로 보강 필요. 시 장르는 comma_pos_diversity 분리도가 약하므로 (genre=='poetry') 가드 권장."
+ },
+ "lexicons": {
+  "conclusion_pivot": [
+   "결론적으로",
+   "따라서",
+   "이를 통해",
+   "그러므로"
+  ],
+  "safe_balance": [
+   "양쪽 모두",
+   "두 가지 모두",
+   "장점도 있지만",
+   "신중하게",
+   "균형"
+  ],
+  "hanja_nominalizers": [
+   "성",
+   "적",
+   "화"
+  ],
+  "lexicon_thresholds": {
+   "conclusion_pivot": {
+    "per_doc_count": 3,
+    "severity": "S1",
+    "merges_into": "D-1"
+   },
+   "safe_balance": {
+    "per_doc_count": 4,
+    "severity": "S2",
+    "new_code": "G-3"
+   },
+   "hanja_nominalizers": {
+    "per_doc_density": 12,
+    "severity": "S2",
+    "merges_into": "F-4",
+    "unit": "occurrences_per_doc"
+   }
+  }
+ },
+ "lread_calibration": {
+  "human_intuition_acc": 0.6,
+  "human_intuition_p_value": 0.362,
+  "human_intuition_chance_diff": "no statistical difference",
+  "rubric_acc": 0.9,
+  "rubric_fisher_p": 0.015,
+  "rubric_cohens_h": 0.73,
+  "ai_essay_false_negative_drop": {
+   "before": 0.5,
+   "after": 0.083,
+   "fisher_p": 0.003
+  },
+  "zero_shot_llm_majority_acc": 0.9667,
+  "comments": "Phase 1 직관 60%는 chance와 통계적 차이 없음(p=.362) — 일반 독자는 AI 한글 식별 어려움. Phase 2 루브릭(쉼표·연결어미·결산·균형 어휘 등 우리 분류 체계와 정렬)을 제공하면 90%로 급상승. v1.6 detector는 LREAD 루브릭의 측정 지표를 그대로 흡수해 인간 판독 90% 수준 도달이 1차 KPI."
+ },
+ "v1_6_promotion_targets": {
+  "promote": [
+   {
+    "cand_id": "cand-v16-001",
+    "new_code": "C-11",
+    "name": "ending_comma_rate",
+    "severity": "S1",
+    "primary_metric": "ending_comma_rate"
+   },
+   {
+    "cand_id": "cand-v16-002",
+    "new_code": "C-12",
+    "name": "comma_inclusion_rate",
+    "severity": "S2",
+    "primary_metric": "comma_inclusion_rate"
+   },
+   {
+    "cand_id": "cand-v16-003",
+    "new_code": "E-5",
+    "name": "comma_segment_length",
+    "severity": "S2",
+    "primary_metric": "comma_segment_length"
+   },
+   {
+    "cand_id": "cand-v16-004",
+    "new_code": "E-6",
+    "name": "comma_pos_diversity",
+    "severity": "S2",
+    "primary_metric": "comma_pos_diversity",
+    "genre_guard": [
+     "poetry"
+    ]
+   },
+   {
+    "cand_id": "cand-v16-007",
+    "new_code": "G-3",
+    "name": "safe_balance_lexicon",
+    "severity": "S2",
+    "primary_metric": "safe_balance"
+   }
+  ],
+  "merge": [
+   {
+    "cand_id": "cand-v16-006",
+    "into": [
+     "D-1",
+     "H-1",
+     "A-2"
+    ],
+    "patch": "lexicon 4종 정식 인용 + 임계"
+   },
+   {
+    "cand_id": "cand-v16-008",
+    "into": [
+     "F-4"
+    ],
+    "patch": "hanja_nominalizers 3종 명시 + 한 문서 12회 초과 S2 강화 임계"
+   }
+  ],
+  "hold": [
+   {
+    "cand_id": "cand-v16-005",
+    "name": "spacing_regularness",
+    "reason": "보고서 본문에 정량 셀 미공개. 사용자 코퍼스 baseline 확보 후 v1.7 검토. 탐지 전용 신호로만 채용 가능, 윤문 처방 없음(맞춤법 일부러 틀리게 만들지 않음)"
+   },
+   {
+    "cand_id": "cand-v16-009",
+    "name": "persona_register_mismatch",
+    "reason": "v1.5 monolith fast + author-context 미주입과 충돌. 메타 부스터로만 작동하는 옵트인 설계가 정리되면 v1.7+ 검토"
+   }
+  ]
+ }
 }

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -183,6 +183,25 @@ class MetricsTests(unittest.TestCase):
         self.assertEqual(band, "high")
         self.assertEqual(score, 6)
 
+    def test_column_and_report_genre_cells_exist(self) -> None:
+        # SKILL.md 장르 키(column/report)가 baseline 셀 없이 essay로 폴백되던
+        # 구멍(2026-08-29 FPR 실측에서 확인) — 실측 셀 추가 후 폴백 경고가 없어야 한다.
+        text = "그는 학교에 가고, 밥을 먹었다. 결과를 검토했다."
+        for genre in ("column", "report"):
+            with self.subTest(genre=genre):
+                result = metrics.compute_all(text, genre=genre, baseline_path=BASELINE_PATH)
+                self.assertNotIn("warning", result, f"{genre} 셀이 essay로 폴백됨")
+
+    def test_inverted_comma_metrics_disabled_per_genre(self) -> None:
+        # 실측에서 human이 essay-AI 극을 초과(역전)한 지표는 해당 장르에서
+        # 판별 불가 — z가 None이어야 한다.
+        text = "그는 학교에 가고, 밥을 먹고, 잠을 잤다. 보고서를 썼다."
+        col = metrics.compute_all(text, genre="column", baseline_path=BASELINE_PATH)
+        self.assertIsNone(col["z_scores"]["ending_comma_rate"])
+        rep = metrics.compute_all(text, genre="report", baseline_path=BASELINE_PATH)
+        self.assertIsNone(rep["z_scores"]["ending_comma_rate"])
+        self.assertIsNone(rep["z_scores"]["comma_segment_length"])
+
     # ------------------------------------------------------------------
     # CLI smoke
     # ------------------------------------------------------------------


### PR DESCRIPTION
## 배경
FPR 실측(사람 532편)에서 구 판정기 high 오판 285편(53.6%)의 공통 원인이 드러남: SKILL.md는 `--genre column|report`를 받지만 baseline.json에 두 셀이 없어 **essay(KatFish) 셀로 폴백** — 설명문·칼럼의 인간 쉼표 분포(ending_comma_rate 32.9~41.0%)가 essay 인간 극 4.1%와 비교돼 z가 폭주했다. Pebblous 티어다운의 기술 에세이 오판(필자 83%)이 바로 이 구멍.

## 변경
- `column` 셀: 저자 칼럼 11편 실측 / `report` 셀: 위키 설명문 521청크 실측(프록시)
- 인간 실측이 essay-AI 극을 **역전**한 지표(ending_comma_rate 양쪽, report의 comma_segment_length)는 해당 장르에서 판별 불가로 비활성(null)
- AI 극은 장르별 AI 코퍼스 미확보로 global(KatFish) 상속 — `_source`에 명시
- 테스트 2종: 폴백 경고 부재 / 역전 지표 z=None

## 실측 (in-sample 주의)
| | high | medium | low |
|---|---|---|---|
| 구 판정기 + essay 폴백 | 285 (53.6%) | 171 | 76 |
| #119 + essay 폴백 | 0 | 4 (0.8%) | 528 |
| #119 + 장르 셀 (본 PR) | **0** | **0** | **532 (100%)** |

comma_inclusion_rate z는 198편에서 여전히 발화(극간 분리 약함)하나 가족 캡이 흡수 — 셀 note에 단독 증거 금지 기록.

https://claude.ai/code/session_01Bc2zvbdNjAS1J1LTiGmMRh