### PR TITLE
fix(shim): run 디렉터리 동시 배정 충돌 — 원자적 생성 + 세션 태그

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,7 +83,7 @@ im-not-ai/
 │           └── web-service-spec.md     # 웹 확장 스펙 (옵션)
 ├── codex/skills/humanize-korean/  # Codex Fast Path 스킬 (references → SSOT 공유 심링크)
 └── _workspace/                    # 런타임 산출물 (run_id별, gitignored)
-    └── {YYYY-MM-DD-NNN}/
+    └── {YYYY-MM-DD-NNN-TAG}/          # TAG=세션 구분자(동시 실행 충돌 방지)
         ├── 01_input.txt · 00_metrics.json · 01_input_with_metrics.txt  # 원문·점수·결합
         ├── final.md                    # 윤문본 (끝에 <!-- HUMANIZE-SUMMARY --> 블록)
         ├── 01_chunk_{NN}… · 02_chunk_{NN}_rewritten.txt · 03_reassembled.md  # (장문 청킹)

--- a/codex/skills/humanize-korean/SKILL.md
+++ b/codex/skills/humanize-korean/SKILL.md
@@ -23,7 +23,7 @@ description: AI(ChatGPT·Claude·Gemini)가 쓴 한글 텍스트를 사람이 �
 4. **탐지**: A~J 카테고리 패턴을 메모리에서 스캔해 (ID, span, severity, fix) 수집. Do-NOT span은 제외.
 5. **윤문**: D(관용구 삭제) → A → I → G → H → F → B → C·J → E 순서로 문단 단위 처리. 변경률을 모니터링하며 50% 임박 시 후속 edit 보류.
 6. **자체검증**: quick-rules "자체검증 체크리스트" 6항 점검. 위반 항목 발견 시 해당 edit 롤백 → 윤문 부분 재실행(최대 1회).
-7. **출력**: cwd 기준 `_workspace/{run_id}/final.md` 작성(run_id = `YYYY-MM-DD-NNN`, 당일 기존 폴더 있으면 NNN+1). 본문 끝에 빈 줄 하나 두고 `<!-- HUMANIZE-SUMMARY ... -->` HTML 주석 블록 1개 추가:
+7. **출력**: cwd 기준 `_workspace/{run_id}/final.md` 작성(run_id = `YYYY-MM-DD-NNN-TAG`, 당일 기존 폴더 있으면 NNN+1. **TAG 는 세션 구분자** — `python3 -c "import secrets;print(secrets.token_hex(2))"` 로 run 시작 때 한 번 만들어 끝까지 재사용한다. 한 머신에서 세션이 동시에 돌면 NNN 만으로는 서로의 `01_input.txt` 를 덮어쓴다). 본문 끝에 빈 줄 하나 두고 `<!-- HUMANIZE-SUMMARY ... -->` HTML 주석 블록 1개 추가:
    - 원본/윤문본 글자수·변경률
    - 카테고리별 탐지 건수(before → after, quick-rules ID 기준)
    - 자체검증 6항 통과 여부

--- a/scripts/prepare_monolith_input.py
+++ b/scripts/prepare_monolith_input.py
@@ -71,19 +71,36 @@ except Exception:  # pragma: no cover
 # ---------------------------------------------------------------------------
 
 
-def _next_run_dir(workspace: Path) -> Path:
-    """Allocate _workspace/<today>-NNN/ with the smallest free NNN."""
+def _next_run_dir(workspace: Path, session_tag: str | None = None) -> Path:
+    """Allocate _workspace/<today>-NNN[-<tag>]/ with the smallest free NNN.
+
+    **확인과 생성을 한 번에 한다.** 예전에는 `exists()` 로 빈 자리를 보고 호출부가
+    나중에 mkdir 했다. 그 사이에 다른 프로세스가 같은 이름을 잡으면 두 실행이 한
+    디렉터리를 공유한다 — 뒤에 온 쪽이 앞선 쪽의 `01_input.txt` 를 덮어쓰고,
+    게이트는 *남의 원문과 내 윤문본*을 비교해 있지도 않은 제목·인용이 사라졌다며
+    ABORT 를 낸다. 윤문본 자체는 멀쩡하므로 원인을 찾기가 특히 어렵다.
+
+    `session_tag` 를 주면 이름 뒤에 붙어 세션끼리 번호도 겹치지 않는다.
+    `YYYY-MM-DD-` 접두어는 그대로라 기존 Glob 패턴·정렬은 영향받지 않는다.
+    """
     workspace.mkdir(parents=True, exist_ok=True)
     today = date.today().isoformat()
-    n = 1
-    while True:
-        candidate = workspace / f"{today}-{n:03d}"
-        if not candidate.exists():
+    tag = f"-{session_tag}" if session_tag else ""
+    for n in range(1, 1000):
+        candidate = workspace / f"{today}-{n:03d}{tag}"
+        try:
+            candidate.mkdir(parents=True, exist_ok=False)
             return candidate
-        n += 1
+        except FileExistsError:
+            continue
+    raise SystemExit(
+        f"run dir 자리를 못 찾았다: {workspace}/{today}-NNN{tag} 가 999개까지 찼다"
+    )
 
 
-def _resolve_run_dir(run_dir_arg: str | None, text_arg: str | None) -> Path:
+def _resolve_run_dir(
+    run_dir_arg: str | None, text_arg: str | None, session_tag: str | None = None
+) -> Path:
     """상대 경로는 **cwd** 기준으로 푼다.
 
     이전에는 PROJECT_ROOT(설치 저장소 루트) 기준이었다. SKILL.md 는 "모든 경로는
@@ -111,9 +128,7 @@ def _resolve_run_dir(run_dir_arg: str | None, text_arg: str | None) -> Path:
     if text_arg is None:
         raise SystemExit("Either --run-dir or --text is required")
     workspace = Path.cwd() / "_workspace"
-    rd = _next_run_dir(workspace)
-    rd.mkdir(parents=True, exist_ok=True)
-    return rd
+    return _next_run_dir(workspace, session_tag)  # 생성까지 원자적으로 끝난다
 
 
 # ---------------------------------------------------------------------------
@@ -708,7 +723,7 @@ def _render_chunk_header(index: int, total: int, starts_with_heading: bool) -> s
 
 
 def run_chunk_mode(args: argparse.Namespace, diagnosis: str | None) -> int:
-    run_dir = _resolve_run_dir(args.run_dir, args.text)
+    run_dir = _resolve_run_dir(args.run_dir, args.text, args.session_tag)
     input_path = run_dir / "01_input.txt"
     if args.text is not None:
         input_path.write_text(args.text, encoding="utf-8")
@@ -856,6 +871,13 @@ def main(argv: list[str] | None = None) -> int:
     p = argparse.ArgumentParser(description="Humanize KR v2.0 monolith input shim")
     p.add_argument("--run-dir", help="Existing run directory (relative ok)")
     p.add_argument("--text", help="Inline text input (creates new run dir)")
+    p.add_argument(
+        "--session-tag",
+        default=None,
+        help="run 디렉터리 이름 뒤에 붙는 세션 구분자(예: a3f9). 한 머신에서 여러 "
+        "세션이 동시에 돌 때 _workspace/<날짜>-NNN 을 서로 덮어쓰는 사고를 막는다. "
+        "--text 로 새 디렉터리를 만들 때만 쓰인다.",
+    )
     p.add_argument("--genre", default="essay", help="Genre hint (default: essay)")
     p.add_argument(
         "--baseline",
@@ -895,7 +917,7 @@ def main(argv: list[str] | None = None) -> int:
     if args.chunk:
         return run_chunk_mode(args, diagnosis)
 
-    run_dir = _resolve_run_dir(args.run_dir, args.text)
+    run_dir = _resolve_run_dir(args.run_dir, args.text, args.session_tag)
     input_path = run_dir / "01_input.txt"
 
     # Ensure 01_input.txt exists.

--- a/skills/humanize-korean/SKILL.md
+++ b/skills/humanize-korean/SKILL.md
@@ -16,7 +16,7 @@ description: AI(ChatGPT·Claude·Gemini 등)가 쓴 한글 텍스트를 "사람�
 작업 시작 시 가장 먼저 다음 한 줄을 사용자에게 출력한다.
 
 ```
-humanize-korean v2.3 — 경로: {light|standard|heavy} ({route_hint|사용자 지정}) / run_id: {YYYY-MM-DD-NNN}
+humanize-korean v2.3 — 경로: {light|standard|heavy} ({route_hint|사용자 지정}) / run_id: {YYYY-MM-DD-NNN-TAG}
 ```
 
 (경로는 Phase 1의 shim 실행 후에 확정되므로, 이 상태 줄은 shim 직후 출력한다.)
@@ -36,13 +36,27 @@ humanize-korean v2.3 — 경로: {light|standard|heavy} ({route_hint|사용자 �
 5. **입력 길이는 경로를 바꾸지 않는다.** 1만자급도 단일 콜로 처리한다(§설계 노트의 실측 근거 참조). 길이·중증도 판단은 shim의 route_hint에 위임한다.
 
 ### run_id 결정
-- 모든 경로는 **cwd 기준**. 새 폴더 생성도 cwd 기준 `_workspace/{YYYY-MM-DD-NNN}/`에 만든다.
+- 모든 경로는 **cwd 기준**. 새 폴더 생성도 cwd 기준 `_workspace/{YYYY-MM-DD-NNN-TAG}/`에 만든다.
+- **`TAG` 는 세션 구분자다. Phase 1 맨 처음에 한 번 만들어 그 run 내내 재사용한다.**
+
+  ```bash
+  TAG=$(python3 -c "import secrets;print(secrets.token_hex(2))")   # 예: a3f9
+  ```
+
+  이후 모든 명령의 `_workspace/{run_id}` 에 같은 TAG 를 쓴다. 중간에 새로 만들지 않는다.
 - 기존 시퀀스 확인은 **`Glob` 도구**로 표지 파일을 매칭해 간접 조회.
   올바른 사용법: `Glob(pattern="_workspace/YYYY-MM-DD-*/01_input.txt")` → 결과에서 폴더명 추출 후 NNN 최댓값 + 1.
+  (`-TAG` 가 뒤에 붙어도 접두어가 같아 이 패턴은 그대로 맞는다.)
   주의: Glob은 디렉토리 자체는 매칭하지 못한다. 반드시 그 안의 표지 파일(`01_input.txt`)을 매칭할 것.
   `Bash ls`는 OS·셸 환경에 따라 경로 해석이 달라지므로 사용 금지.
 - 당일 폴더가 없으면 NNN = 001. 있으면 마지막 NNN + 1.
-- 부분 재실행 신호("이 카테고리만 다시"·"2차 윤문")일 경우 기존 run_id 재사용 + heavy 경로로 자동 승급.
+- 부분 재실행 신호("이 카테고리만 다시"·"2차 윤문")일 경우 기존 run_id 재사용(TAG 포함) + heavy 경로로 자동 승급.
+
+> 🔴 **TAG 를 빼지 마라.** 한 머신에서 세션이 여러 개 동시에 도는 환경에서는 NNN 만으로
+> 겹친다. Glob 으로 자리를 확인하고 `mkdir` 하기까지 틈이 있어 다른 세션이 같은 번호를
+> 잡기 때문이다. 두 세션이 한 디렉터리를 쓰면 서로의 `01_input.txt` 를 덮어쓰고, 게이트가
+> *남의 원문과 내 윤문본*을 비교해 있지도 않은 제목·인용이 사라졌다며 ABORT 를 낸다.
+> 윤문본 자체는 멀쩡하므로 원인을 찾기가 특히 어렵다.
 
 ## 스크립트 경로 규칙 (`${SKILL_ROOT}`)
 
@@ -78,7 +92,7 @@ SKILL_ROOT="$(d="$(cd -P "${CLAUDE_SKILL_DIR}" && pwd)"; \
    python3 ${SKILL_ROOT}/scripts/prepare_monolith_input.py --run-dir _workspace/{run_id} --genre {genre}
    ```
    - `--genre` 값은 영문 키: `essay | column | report | blog | abstract` (생략 시 `essay`). 장르 힌트 매핑: 칼럼→`column`, 리포트→`report`, 블로그→`blog`, 공적/기타→`essay`.
-   - `--run-dir`·`--diagnosis`의 상대 경로는 **cwd 기준**으로 해석된다(위 run_id 규칙과 동일 기준). 그 외 인자: `--text`(run-dir 없이 즉석 실행 시 새 run 디렉토리 자동 생성), `--baseline`(baseline JSON 경로 override, 평소 불필요), `--diagnosis`(진단 텍스트 파일을 점수 블록 앞에 prepend — standard·heavy의 진단 결합용).
+   - `--run-dir`·`--diagnosis`의 상대 경로는 **cwd 기준**으로 해석된다(위 run_id 규칙과 동일 기준). 그 외 인자: `--text`(run-dir 없이 즉석 실행 시 새 run 디렉토리 자동 생성 — 이때는 `--session-tag {TAG}` 를 같이 준다), `--baseline`(baseline JSON 경로 override, 평소 불필요), `--diagnosis`(진단 텍스트 파일을 점수 블록 앞에 prepend — standard·heavy의 진단 결합용).
    - 산출: `00_metrics.json`(정량 점수 + **`route_hint`**) + `01_input_with_metrics.txt`(점수 블록을 원문 앞에 붙인 결합 파일).
    - **graceful degrade 내장**: metrics 계산이 실패하면 shim이 점수 블록 없이 원문만 감싼 결합 파일을 쓰고 `00_metrics.error`를 남긴다. 이 경우 route_hint 없음 → standard 경로.
 5. `00_metrics.json`의 `route_hint`를 읽어 Phase 0 규칙대로 경로를 확정하고 상태 줄을 출력한다.

--- a/tests/test_run_dir_allocation.py
+++ b/tests/test_run_dir_allocation.py
@@ -1,0 +1,79 @@
+"""run 디렉터리 배정의 동시성 회귀 테스트.
+
+배경: `_next_run_dir` 이 `exists()` 로 빈 자리를 확인만 하고 실제 생성은 호출부가
+나중에 했다. 그 틈에 다른 프로세스가 같은 이름을 잡으면 두 실행이 한 디렉터리를
+공유하고, 뒤에 온 쪽이 앞선 쪽의 `01_input.txt` 를 덮어쓴다. 그러면 게이트가
+*남의 원문과 내 윤문본*을 비교해 있지도 않은 제목·인용이 사라졌다며 ABORT 를 낸다.
+
+Runs under pytest OR `python -m unittest`.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import tempfile
+import unittest
+from concurrent.futures import ThreadPoolExecutor
+from datetime import date
+from pathlib import Path
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+PROJECT_ROOT = os.path.abspath(os.path.join(HERE, ".."))
+SCRIPTS_DIR = os.path.join(PROJECT_ROOT, "scripts")
+if SCRIPTS_DIR not in sys.path:
+    sys.path.insert(0, SCRIPTS_DIR)
+
+from prepare_monolith_input import _next_run_dir  # noqa: E402
+
+
+class NextRunDirTests(unittest.TestCase):
+    def test_sequential_allocation_increments(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            ws = Path(tmp) / "_workspace"
+            today = date.today().isoformat()
+            first = _next_run_dir(ws)
+            second = _next_run_dir(ws)
+            self.assertEqual(first.name, f"{today}-001")
+            self.assertEqual(second.name, f"{today}-002")
+
+    def test_allocation_creates_the_directory(self) -> None:
+        """배정과 동시에 실물 디렉터리가 있어야 한다 — 확인·생성 사이의 틈을 없앤다."""
+        with tempfile.TemporaryDirectory() as tmp:
+            ws = Path(tmp) / "_workspace"
+            self.assertTrue(_next_run_dir(ws).is_dir())
+
+    def test_concurrent_allocation_never_collides(self) -> None:
+        """동시 배정 N건 → 서로 다른 디렉터리 N개. 옛 로직은 전부 -001 을 받았다."""
+        workers = 16
+        with tempfile.TemporaryDirectory() as tmp:
+            ws = Path(tmp) / "_workspace"
+            ws.mkdir(parents=True, exist_ok=True)
+            with ThreadPoolExecutor(max_workers=workers) as pool:
+                dirs = list(pool.map(lambda _: _next_run_dir(ws), range(workers)))
+            self.assertEqual(len(dirs), workers)
+            self.assertEqual(len({d.name for d in dirs}), workers)
+
+    def test_session_tag_keeps_sessions_apart(self) -> None:
+        """세션 태그가 다르면 같은 NNN 이어도 서로 다른 디렉터리다."""
+        with tempfile.TemporaryDirectory() as tmp:
+            ws = Path(tmp) / "_workspace"
+            today = date.today().isoformat()
+            a = _next_run_dir(ws, "a3f9")
+            b = _next_run_dir(ws, "b7c2")
+            self.assertEqual(a.name, f"{today}-001-a3f9")
+            self.assertEqual(b.name, f"{today}-001-b7c2")
+            self.assertNotEqual(a, b)
+
+    def test_tagged_and_untagged_do_not_clash(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            ws = Path(tmp) / "_workspace"
+            today = date.today().isoformat()
+            plain = _next_run_dir(ws)
+            tagged = _next_run_dir(ws, "a3f9")
+            self.assertEqual(plain.name, f"{today}-001")
+            self.assertEqual(tagged.name, f"{today}-001-a3f9")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 무엇이 문제인가

`_next_run_dir` 이 `exists()` 로 빈 자리를 **확인만** 하고, 실제 생성은 호출부가 나중에 합니다. 그 사이에 다른 프로세스가 같은 이름을 잡으면 두 실행이 한 디렉터리를 공유합니다.

```python
candidate = workspace / f"{today}-{n:03d}"
if not candidate.exists():
    return candidate          # ← 여기서 반환하고
...
rd.mkdir(parents=True, exist_ok=True)   # ← 생성은 나중에. 그 사이가 열려 있다
```

한 머신에서 세션을 여러 개 띄우고 쓰면 재현됩니다. 옛 로직을 그대로 떼어 6개를 동시에 돌리면 **전부 `-001` 을 받습니다.**

## 왜 알아채기 어려운가

증상이 엉뚱한 데서 터집니다. 뒤에 온 쪽이 앞선 쪽의 `01_input.txt` 를 덮어쓰므로, `verify_gates.py` 가 **남의 원문과 내 윤문본**을 비교하게 됩니다. 그러면 이런 판정이 나옵니다.

```
FAIL [heading_lost] 제목 '## 재는 법'이 윤문본에서 사라졌습니다
FAIL [quote_altered] 직접 인용 「음식은 요리된다…」이 윤문본에 원문 그대로 없습니다
[P4 터치율] 100.0% (104/104 문장)
gate: ABORT — 강제 중단. 윤문본 채택 금지
```

제 글에는 그런 제목도 인용도 없었습니다. **윤문본 자체는 멀쩡한데 판정만 망가진 것**이라, 처음엔 윤문 품질 문제로 의심하게 됩니다.

## 고친 것

- **`_next_run_dir`** — `mkdir(exist_ok=False)` 로 확인과 생성을 한 번에. 이미 있으면 다음 번호로 넘어가고, 999까지 차면 명시적으로 실패합니다.
- **`--session-tag`** — run 디렉터리 이름 뒤에 붙는 세션 구분자(`2026-09-01-001-a3f9`). 세션이 동시에 도는 환경에서 번호까지 분리합니다. **선택 인자라 안 쓰면 기존과 똑같이 동작합니다.**
- **`SKILL.md`** — run_id 를 `YYYY-MM-DD-NNN-TAG` 로. TAG 는 Phase 1에서 한 번 만들어 run 내내 재사용하도록 했습니다. 오케스트레이터가 `Glob` 으로 자리를 보고 `mkdir` 하는 경로에도 같은 틈이 있어서, 스크립트만 고쳐서는 안 막힙니다.
- **`codex/skills/…/SKILL.md`, `CLAUDE.md`** — 같은 규칙이 세 군데 있어 표기를 맞췄습니다.

## 호환성

`YYYY-MM-DD-` 접두어가 그대로라 `Glob(pattern="_workspace/YYYY-MM-DD-*/01_input.txt")` 와 날짜 정렬은 영향받지 않습니다. `--session-tag` 를 주지 않으면 디렉터리 이름도 종전과 동일합니다.

## 테스트

`tests/test_run_dir_allocation.py` 5건을 추가했습니다 — 순차 증가 · 배정 시 실제 생성 · **동시 16건 무충돌** · 태그로 세션 분리 · 태그/무태그 공존.

옛 코드에서는 5건 중 5건이 실패하고(`'2026-09-01-001' != '2026-09-01-002'`), 고친 뒤 전부 통과합니다.

기존 테스트 회귀 없음: `test_metrics_v2`(60) · `test_metrics` · `test_chunking`(ratio 1.0, warnings 0) · `test_humanize_e2e` · `test_diagnosis_rules_build` · `test_content_anchor_contract` · `test_agent_inventory` 모두 통과.